### PR TITLE
[codex] Resolve hostname and backup issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,6 +126,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "dot-conf"
 version = "0.1.0"
 dependencies = [
@@ -133,6 +142,7 @@ dependencies = [
  "clap",
  "env_logger",
  "home",
+ "hostname",
  "libc",
  "log",
  "serde",
@@ -141,6 +151,7 @@ dependencies = [
  "symlink",
  "temp-env",
  "tempfile",
+ "time",
 ]
 
 [[package]]
@@ -273,6 +284,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "hostname"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-link",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -376,6 +398,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -430,6 +458,12 @@ checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "prettyplease"
@@ -688,6 +722,37 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,12 @@ clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 log = "0.4"
 env_logger = "0.11"
+hostname = "0.4"
 libc = "0.2"
 serde_yml = "0.0.12"
 home = "0.5.12"
 symlink = "0.1.0"
+time = { version = "0.3", features = ["formatting"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ symlinks:
   .tmux.conf:
     - ~/.tmux.conf
     - ~/.config/tmux/tmux.conf
+  jupyter_notebook_config.py:
+    destinations: ~/.jupyter/jupyter_notebook_config.py
+    hosts:
+      - work-laptop
+      - lab-workstation
 sys_symlinks:
   .sysrc: /etc/sysrc
 ```
@@ -64,8 +69,10 @@ Options:
 - Source paths and relative `backup_directory` paths are resolved relative to the YAML file.
 - Relative destination paths are resolved relative to the current working directory.
 - Destination and backup paths support `~` expansion for the current user's home directory.
+- A symlink entry can use `destinations` plus `host` or `hosts` to apply only on matching hostnames.
 - Missing source files are skipped with a warning.
 - Backup directories are created lazily only when an existing destination is backed up.
+- Backup filenames include the destination name, a readable UTC timestamp, and a destination hash.
 - Applying links is not transactional; if a later link in a scope fails, earlier links in that scope may already have been applied or backed up.
 
 ## CI and release process

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ symlinks:
       - lab-workstation
 ```
 
-`dot-conf` reads the current hostname from the operating system and compares configured hosts case-insensitively against both the full hostname and the short name before the first dot. For example, a machine named `work-laptop.example.com` matches either `work-laptop.example.com` or `work-laptop`.
+`dot-conf` reads the current hostname from the operating system and compares configured hosts case-insensitively. A short configured host such as `work-laptop` matches either `work-laptop` or a full current hostname such as `work-laptop.example.com`. A configured fully-qualified host such as `work-laptop.example.com` requires the operating system to report that exact full hostname, which avoids guessing when two domains share the same short host name.
 
 ## Behavior notes
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,21 @@ Options:
 - `--user-only` only apply `symlinks`
 - `--sys-only` only apply `sys_symlinks`
 
+## Host matching
+
+Use your system hostname in a `host` or `hosts` filter when a link should only apply on some machines. On most systems, `hostname` prints the full name and `hostname -s` prints the short name.
+
+```yaml
+symlinks:
+  jupyter_notebook_config.py:
+    destinations: ~/.jupyter/jupyter_notebook_config.py
+    hosts:
+      - work-laptop
+      - lab-workstation
+```
+
+`dot-conf` reads the current hostname from the operating system and compares configured hosts case-insensitively against both the full hostname and the short name before the first dot. For example, a machine named `work-laptop.example.com` matches either `work-laptop.example.com` or `work-laptop`.
+
 ## Behavior notes
 
 - Source paths and relative `backup_directory` paths are resolved relative to the YAML file.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,10 +7,11 @@ use std::fs;
 use std::hash::{Hash, Hasher};
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::SystemTime;
 
-use anyhow::{bail, Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use serde::Deserialize;
+use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 
 /// Which configured links to apply.
 ///
@@ -32,9 +33,9 @@ pub enum Scope {
 struct RawConfig {
     backup_directory: PathBuf,
     #[serde(default)]
-    symlinks: BTreeMap<PathBuf, OneOrMany>,
+    symlinks: BTreeMap<PathBuf, RawLink>,
     #[serde(default)]
-    sys_symlinks: BTreeMap<PathBuf, OneOrMany>,
+    sys_symlinks: BTreeMap<PathBuf, RawLink>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -49,6 +50,53 @@ impl OneOrMany {
         match self {
             Self::One(path) => vec![path],
             Self::Many(paths) => paths,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum OneOrManyString {
+    One(String),
+    Many(Vec<String>),
+}
+
+impl Default for OneOrManyString {
+    fn default() -> Self {
+        Self::Many(Vec::new())
+    }
+}
+
+impl OneOrManyString {
+    fn into_vec(self) -> Vec<String> {
+        match self {
+            Self::One(value) => vec![value],
+            Self::Many(values) => values,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum RawLink {
+    Destinations(OneOrMany),
+    Options(RawLinkOptions),
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawLinkOptions {
+    #[serde(alias = "destination")]
+    destinations: OneOrMany,
+    #[serde(default, alias = "host")]
+    hosts: OneOrManyString,
+}
+
+impl RawLink {
+    fn into_parts(self) -> (OneOrMany, Vec<String>) {
+        match self {
+            Self::Destinations(destinations) => (destinations, Vec::new()),
+            Self::Options(options) => (options.destinations, options.hosts.into_vec()),
         }
     }
 }
@@ -89,11 +137,22 @@ impl DotConf {
     /// current directory.
     pub fn from_yaml_str(yaml: &str, source_base: &Path, destination_base: &Path) -> Result<Self> {
         let raw: RawConfig = serde_yml::from_str(yaml).context("failed parsing YAML")?;
+        let mut current_host = None;
         Ok(Self {
             backup_directory: resolve_against(source_base, &raw.backup_directory)
                 .with_context(|| format!("failed resolving {}", raw.backup_directory.display()))?,
-            symlinks: normalize_links(source_base, destination_base, raw.symlinks)?,
-            sys_symlinks: normalize_links(source_base, destination_base, raw.sys_symlinks)?,
+            symlinks: normalize_links(
+                source_base,
+                destination_base,
+                raw.symlinks,
+                &mut current_host,
+            )?,
+            sys_symlinks: normalize_links(
+                source_base,
+                destination_base,
+                raw.sys_symlinks,
+                &mut current_host,
+            )?,
         })
     }
 
@@ -148,10 +207,22 @@ impl DotConf {
 fn normalize_links(
     source_base: &Path,
     destination_base: &Path,
-    links: BTreeMap<PathBuf, OneOrMany>,
+    links: BTreeMap<PathBuf, RawLink>,
+    current_host: &mut Option<String>,
 ) -> Result<BTreeMap<PathBuf, Vec<PathBuf>>> {
     let mut normalized = BTreeMap::new();
-    for (source, destinations) in links {
+    for (source, raw_link) in links {
+        let (destinations, hosts) = raw_link.into_parts();
+        if !hosts.is_empty() {
+            if current_host.is_none() {
+                *current_host = Some(current_hostname()?);
+            }
+            let hostname = current_host.as_deref().expect("hostname was initialized");
+            if !host_matches(&hosts, hostname) {
+                continue;
+            }
+        }
+
         let resolved_source = resolve_against(source_base, &source)
             .with_context(|| format!("failed resolving source {}", source.display()))?;
         let resolved_destinations = destinations
@@ -166,6 +237,32 @@ fn normalize_links(
         normalized.insert(resolved_source, resolved_destinations);
     }
     Ok(normalized)
+}
+
+fn current_hostname() -> Result<String> {
+    if let Ok(hostname) = std::env::var("DOT_CONF_HOSTNAME") {
+        return Ok(hostname);
+    }
+
+    hostname::get()
+        .context("failed reading hostname")?
+        .into_string()
+        .map_err(|hostname| {
+            anyhow!(
+                "hostname is not valid UTF-8: {}",
+                hostname.to_string_lossy()
+            )
+        })
+}
+
+fn host_matches(hosts: &[String], current_host: &str) -> bool {
+    let current_short = current_host
+        .split_once('.')
+        .map_or(current_host, |(short, _)| short);
+
+    hosts.iter().any(|host| {
+        host.eq_ignore_ascii_case(current_host) || host.eq_ignore_ascii_case(current_short)
+    })
 }
 
 fn resolve_from_cwd(path: &Path) -> Result<PathBuf> {
@@ -293,16 +390,23 @@ fn unique_backup_path(backup_directory: &Path, destination: &Path) -> Result<Pat
     fs::create_dir_all(backup_directory)
         .with_context(|| format!("failed creating {}", backup_directory.display()))?;
 
-    let ts = SystemTime::now().duration_since(UNIX_EPOCH)?.as_nanos();
+    let timestamp = backup_timestamp(SystemTime::now())?;
     let name = backup_name(destination);
     let hash = path_hash(destination);
-    let backup = backup_directory.join(format!("{name}.{hash:016x}.{ts}.bak"));
+    let backup = backup_directory.join(format!("{name}.{timestamp}.{hash:016x}.bak"));
 
     match fs::symlink_metadata(&backup) {
         Ok(_) => bail!("backup path {} already exists", backup.display()),
         Err(err) if err.kind() == ErrorKind::NotFound => Ok(backup),
         Err(err) => Err(err).with_context(|| format!("failed inspecting {}", backup.display())),
     }
+}
+
+fn backup_timestamp(now: SystemTime) -> Result<String> {
+    let timestamp = OffsetDateTime::from(now)
+        .format(&Rfc3339)
+        .context("failed formatting backup timestamp")?;
+    Ok(timestamp.replace(':', "-"))
 }
 
 fn symlink_backup_target(destination: &Path) -> Result<PathBuf> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -257,13 +257,12 @@ fn current_hostname() -> Result<String> {
 }
 
 fn host_matches(hosts: &[String], current_host: &str) -> bool {
-    let (current_short, current_is_fqdn) = hostname_parts(current_host);
+    let (current_short, _) = hostname_parts(current_host);
 
     hosts.iter().any(|host| {
-        let (host_short, host_is_fqdn) = hostname_parts(host);
+        let (_, host_is_fqdn) = hostname_parts(host);
         host.eq_ignore_ascii_case(current_host)
             || (!host_is_fqdn && host.eq_ignore_ascii_case(current_short))
-            || (!current_is_fqdn && host_short.eq_ignore_ascii_case(current_host))
     })
 }
 
@@ -561,12 +560,17 @@ mod tests {
         ));
         assert!(host_matches(
             &[String::from("workstation.example.test")],
-            "workstation"
+            "workstation.example.test"
         ));
         assert!(host_matches(
             &[String::from("WORKSTATION")],
             "workstation.example.test"
         ));
+        assert!(!host_matches(
+            &[String::from("workstation.example.test")],
+            "workstation"
+        ));
+        assert!(host_matches(&[String::from("workstation")], "workstation"));
         assert!(!host_matches(
             &[String::from("workstation.other.test")],
             "workstation.example.test"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,8 +105,14 @@ impl RawLink {
 #[derive(Debug)]
 pub struct DotConf {
     backup_directory: PathBuf,
-    symlinks: BTreeMap<PathBuf, Vec<PathBuf>>,
-    sys_symlinks: BTreeMap<PathBuf, Vec<PathBuf>>,
+    symlinks: BTreeMap<PathBuf, LinkConfig>,
+    sys_symlinks: BTreeMap<PathBuf, LinkConfig>,
+}
+
+#[derive(Debug)]
+struct LinkConfig {
+    destinations: Vec<PathBuf>,
+    hosts: Vec<String>,
 }
 
 impl DotConf {
@@ -137,22 +143,11 @@ impl DotConf {
     /// current directory.
     pub fn from_yaml_str(yaml: &str, source_base: &Path, destination_base: &Path) -> Result<Self> {
         let raw: RawConfig = serde_yml::from_str(yaml).context("failed parsing YAML")?;
-        let mut current_host = None;
         Ok(Self {
             backup_directory: resolve_against(source_base, &raw.backup_directory)
                 .with_context(|| format!("failed resolving {}", raw.backup_directory.display()))?,
-            symlinks: normalize_links(
-                source_base,
-                destination_base,
-                raw.symlinks,
-                &mut current_host,
-            )?,
-            sys_symlinks: normalize_links(
-                source_base,
-                destination_base,
-                raw.sys_symlinks,
-                &mut current_host,
-            )?,
+            symlinks: normalize_links(source_base, destination_base, raw.symlinks)?,
+            sys_symlinks: normalize_links(source_base, destination_base, raw.sys_symlinks)?,
         })
     }
 
@@ -166,19 +161,34 @@ impl DotConf {
     /// Existing file and symlink destinations are backed up before they are
     /// replaced. Missing source files are skipped with a warning.
     pub fn apply(&self, scope: Scope) -> Result<()> {
+        let mut current_host = None;
         match scope {
             Scope::All => {
-                self.apply_links(&self.sys_symlinks)?;
-                self.apply_links(&self.symlinks)?;
+                self.apply_links(&self.sys_symlinks, &mut current_host)?;
+                self.apply_links(&self.symlinks, &mut current_host)?;
             }
-            Scope::User => self.apply_links(&self.symlinks)?,
-            Scope::Sys => self.apply_links(&self.sys_symlinks)?,
+            Scope::User => self.apply_links(&self.symlinks, &mut current_host)?,
+            Scope::Sys => self.apply_links(&self.sys_symlinks, &mut current_host)?,
         }
         Ok(())
     }
 
-    fn apply_links(&self, links: &BTreeMap<PathBuf, Vec<PathBuf>>) -> Result<()> {
-        for (source, destinations) in links {
+    fn apply_links(
+        &self,
+        links: &BTreeMap<PathBuf, LinkConfig>,
+        current_host: &mut Option<String>,
+    ) -> Result<()> {
+        for (source, link) in links {
+            if !link.hosts.is_empty() {
+                if current_host.is_none() {
+                    *current_host = Some(current_hostname()?);
+                }
+                let hostname = current_host.as_deref().expect("hostname was initialized");
+                if !host_matches(&link.hosts, hostname) {
+                    continue;
+                }
+            }
+
             match fs::metadata(source) {
                 Ok(_) => {}
                 Err(err) if err.kind() == ErrorKind::NotFound => {
@@ -191,7 +201,7 @@ impl DotConf {
                 }
             };
 
-            for destination in destinations {
+            for destination in &link.destinations {
                 if let Some(parent) = destination.parent() {
                     fs::create_dir_all(parent)
                         .with_context(|| format!("failed creating {}", parent.display()))?;
@@ -208,21 +218,10 @@ fn normalize_links(
     source_base: &Path,
     destination_base: &Path,
     links: BTreeMap<PathBuf, RawLink>,
-    current_host: &mut Option<String>,
-) -> Result<BTreeMap<PathBuf, Vec<PathBuf>>> {
+) -> Result<BTreeMap<PathBuf, LinkConfig>> {
     let mut normalized = BTreeMap::new();
     for (source, raw_link) in links {
         let (destinations, hosts) = raw_link.into_parts();
-        if !hosts.is_empty() {
-            if current_host.is_none() {
-                *current_host = Some(current_hostname()?);
-            }
-            let hostname = current_host.as_deref().expect("hostname was initialized");
-            if !host_matches(&hosts, hostname) {
-                continue;
-            }
-        }
-
         let resolved_source = resolve_against(source_base, &source)
             .with_context(|| format!("failed resolving source {}", source.display()))?;
         let resolved_destinations = destinations
@@ -234,16 +233,18 @@ fn normalize_links(
                 })
             })
             .collect::<Result<Vec<_>>>()?;
-        normalized.insert(resolved_source, resolved_destinations);
+        normalized.insert(
+            resolved_source,
+            LinkConfig {
+                destinations: resolved_destinations,
+                hosts,
+            },
+        );
     }
     Ok(normalized)
 }
 
 fn current_hostname() -> Result<String> {
-    if let Ok(hostname) = std::env::var("DOT_CONF_HOSTNAME") {
-        return Ok(hostname);
-    }
-
     hostname::get()
         .context("failed reading hostname")?
         .into_string()
@@ -256,13 +257,20 @@ fn current_hostname() -> Result<String> {
 }
 
 fn host_matches(hosts: &[String], current_host: &str) -> bool {
-    let current_short = current_host
-        .split_once('.')
-        .map_or(current_host, |(short, _)| short);
+    let (current_short, current_is_fqdn) = hostname_parts(current_host);
 
     hosts.iter().any(|host| {
-        host.eq_ignore_ascii_case(current_host) || host.eq_ignore_ascii_case(current_short)
+        let (host_short, host_is_fqdn) = hostname_parts(host);
+        host.eq_ignore_ascii_case(current_host)
+            || (!host_is_fqdn && host.eq_ignore_ascii_case(current_short))
+            || (!current_is_fqdn && host_short.eq_ignore_ascii_case(current_host))
     })
+}
+
+fn hostname_parts(hostname: &str) -> (&str, bool) {
+    hostname
+        .split_once('.')
+        .map_or((hostname, false), |(short, _)| (short, true))
 }
 
 fn resolve_from_cwd(path: &Path) -> Result<PathBuf> {
@@ -543,6 +551,26 @@ mod tests {
         let expanded = expand_tilde_with_home(&path, Some(Path::new("/tmp/home"))).unwrap();
 
         assert_eq!(expanded.as_os_str().as_bytes(), b"/tmp/home/foo\xffbar");
+    }
+
+    #[test]
+    fn host_matching_accepts_short_and_full_names() {
+        assert!(host_matches(
+            &[String::from("workstation")],
+            "workstation.example.test"
+        ));
+        assert!(host_matches(
+            &[String::from("workstation.example.test")],
+            "workstation"
+        ));
+        assert!(host_matches(
+            &[String::from("WORKSTATION")],
+            "workstation.example.test"
+        ));
+        assert!(!host_matches(
+            &[String::from("workstation.other.test")],
+            "workstation.example.test"
+        ));
     }
 
     #[cfg(windows)]

--- a/tests/dot_conf_test.rs
+++ b/tests/dot_conf_test.rs
@@ -23,6 +23,17 @@ fn with_home<R>(path: &Path, test: impl FnOnce() -> R) -> R {
     temp_env::with_vars(vars, test)
 }
 
+fn with_home_and_hostname<R>(path: &Path, hostname: &str, test: impl FnOnce() -> R) -> R {
+    let vars: [(&str, Option<&OsStr>); 5] = [
+        ("HOME", Some(path.as_os_str())),
+        ("USERPROFILE", Some(path.as_os_str())),
+        ("HOMEDRIVE", None),
+        ("HOMEPATH", None),
+        ("DOT_CONF_HOSTNAME", Some(OsStr::new(hostname))),
+    ];
+    temp_env::with_vars(vars, test)
+}
+
 #[cfg(unix)]
 fn create_file_symlink(source: &Path, destination: &Path) {
     std::os::unix::fs::symlink(source, destination).unwrap();
@@ -138,6 +149,57 @@ symlinks:
             .collect();
         assert_eq!(backups.len(), 1);
         assert_eq!(fs::read_to_string(&backups[0]).unwrap(), "old");
+
+        let backup_name = backups[0].file_name().unwrap().to_string_lossy();
+        assert!(backup_name.starts_with(".vimrc."));
+        assert!(backup_name.ends_with(".bak"));
+        assert!(backup_name.contains('T'));
+        assert!(backup_name.contains("Z."));
+        assert!(!backup_name.contains(':'));
+    });
+}
+
+#[test]
+#[serial]
+fn applies_matching_host_links_only() {
+    let tmp = tempdir().unwrap();
+    let root = tmp.path();
+    let home = root.join("home");
+    let cfg_dir = root.join("cfg");
+    fs::create_dir_all(&home).unwrap();
+    fs::create_dir_all(&cfg_dir).unwrap();
+    with_home_and_hostname(&home, "workstation.example.test", || {
+        write_file(&cfg_dir.join("always"), "always");
+        write_file(&cfg_dir.join("work"), "work");
+        write_file(&cfg_dir.join("personal"), "personal");
+
+        let yaml = cfg_dir.join("config.yaml");
+        fs::write(
+            &yaml,
+            r#"backup_directory: ~/.config/backup
+symlinks:
+  always: ~/always
+  work:
+    destinations: ~/work
+    host: workstation
+  personal:
+    destinations:
+      - ~/personal
+    hosts:
+      - personal-laptop
+      - travel-laptop
+"#,
+        )
+        .unwrap();
+
+        DotConf::from_yaml_file(&yaml)
+            .unwrap()
+            .apply(Scope::User)
+            .unwrap();
+
+        assert!(home.join("always").is_symlink());
+        assert!(home.join("work").is_symlink());
+        assert!(!home.join("personal").exists());
     });
 }
 

--- a/tests/dot_conf_test.rs
+++ b/tests/dot_conf_test.rs
@@ -23,15 +23,24 @@ fn with_home<R>(path: &Path, test: impl FnOnce() -> R) -> R {
     temp_env::with_vars(vars, test)
 }
 
-fn with_home_and_hostname<R>(path: &Path, hostname: &str, test: impl FnOnce() -> R) -> R {
-    let vars: [(&str, Option<&OsStr>); 5] = [
-        ("HOME", Some(path.as_os_str())),
-        ("USERPROFILE", Some(path.as_os_str())),
-        ("HOMEDRIVE", None),
-        ("HOMEPATH", None),
-        ("DOT_CONF_HOSTNAME", Some(OsStr::new(hostname))),
-    ];
-    temp_env::with_vars(vars, test)
+fn current_test_hostname() -> String {
+    hostname::get().unwrap().into_string().unwrap()
+}
+
+fn short_hostname(hostname: &str) -> &str {
+    hostname
+        .split_once('.')
+        .map_or(hostname, |(short, _)| short)
+}
+
+fn non_matching_hostname(hostname: &str) -> String {
+    let short = short_hostname(hostname);
+    let candidate = "dot-conf-unmatched-host";
+    if candidate.eq_ignore_ascii_case(hostname) || candidate.eq_ignore_ascii_case(short) {
+        "dot-conf-unmatched-host-2".to_string()
+    } else {
+        candidate.to_string()
+    }
 }
 
 #[cfg(unix)]
@@ -168,7 +177,10 @@ fn applies_matching_host_links_only() {
     let cfg_dir = root.join("cfg");
     fs::create_dir_all(&home).unwrap();
     fs::create_dir_all(&cfg_dir).unwrap();
-    with_home_and_hostname(&home, "workstation.example.test", || {
+    with_home(&home, || {
+        let hostname = current_test_hostname();
+        let matching_host = short_hostname(&hostname);
+        let non_matching_host = non_matching_hostname(&hostname);
         write_file(&cfg_dir.join("always"), "always");
         write_file(&cfg_dir.join("work"), "work");
         write_file(&cfg_dir.join("personal"), "personal");
@@ -176,19 +188,20 @@ fn applies_matching_host_links_only() {
         let yaml = cfg_dir.join("config.yaml");
         fs::write(
             &yaml,
-            r#"backup_directory: ~/.config/backup
+            format!(
+                r#"backup_directory: ~/.config/backup
 symlinks:
   always: ~/always
   work:
     destinations: ~/work
-    host: workstation
+    host: {matching_host}
   personal:
     destinations:
       - ~/personal
     hosts:
-      - personal-laptop
-      - travel-laptop
-"#,
+      - {non_matching_host}
+"#
+            ),
         )
         .unwrap();
 


### PR DESCRIPTION
## Summary

- Add host-filtered symlink entries with the new `destinations` plus `host`/`hosts` object form while preserving the existing scalar/list destination syntax.
- Generate backup filenames with a readable UTC timestamp plus the existing destination hash.
- Document the host-filter syntax and backup naming behavior.

## Validation

- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`

Closes #3.
Closes #6.