### PR TITLE
[codex] Improve CLI safety and preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ dot-conf config.yaml
 
 Options:
 
-- `--dry-run` preview resolved changes without modifying files or invoking `sudo`
+- `--dry-run` preview resolved changes and path blockers without modifying files or invoking `sudo`
 - `--scope all|user|system` choose which config section(s) to apply
 - `--user-only` only apply `symlinks` (alias for `--scope user`)
 - `--sys-only` only apply `sys_symlinks` (alias for `--scope system`)
@@ -71,6 +71,7 @@ Options:
 - Backup directories are created lazily only when an existing destination is backed up.
 - Config files are all parsed before any changes are applied.
 - When applying both user and system links from a non-root shell, system links are applied with `sudo` first; user links are applied only after that succeeds.
+- Dry runs validate obvious destination and backup-directory blockers. System links that need `sudo` may be reported as needing elevated validation instead of hard-failing from a non-root preview.
 - Applying links is not transactional; if a later link in a scope fails, earlier links in that scope may already have been applied or backed up.
 
 ## CI and release process

--- a/README.md
+++ b/README.md
@@ -56,8 +56,11 @@ dot-conf config.yaml
 
 Options:
 
-- `--user-only` only apply `symlinks`
-- `--sys-only` only apply `sys_symlinks`
+- `--dry-run` preview resolved changes without modifying files or invoking `sudo`
+- `--scope all|user|system` choose which config section(s) to apply
+- `--user-only` only apply `symlinks` (alias for `--scope user`)
+- `--sys-only` only apply `sys_symlinks` (alias for `--scope system`)
+- `-v`, `-vv` increase log verbosity; `-q`, `-qq` reduce it
 
 ## Behavior notes
 
@@ -66,6 +69,8 @@ Options:
 - Destination and backup paths support `~` expansion for the current user's home directory.
 - Missing source files are skipped with a warning.
 - Backup directories are created lazily only when an existing destination is backed up.
+- Config files are all parsed before any changes are applied.
+- When applying both user and system links from a non-root shell, system links are applied with `sudo` first; user links are applied only after that succeeds.
 - Applying links is not transactional; if a later link in a scope fails, earlier links in that scope may already have been applied or backed up.
 
 ## CI and release process

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -680,10 +680,17 @@ fn sticky_directory_allows_replacement(
     destination_uid: u32,
     euid: u32,
 ) -> bool {
-    parent_mode & libc::S_ISVTX as u32 == 0
-        || euid == 0
-        || destination_uid == euid
-        || parent_uid == euid
+    parent_mode & sticky_bit() == 0 || euid == 0 || destination_uid == euid || parent_uid == euid
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn sticky_bit() -> u32 {
+    libc::S_ISVTX
+}
+
+#[cfg(all(unix, not(any(target_os = "linux", target_os = "android"))))]
+fn sticky_bit() -> u32 {
+    libc::S_ISVTX as u32
 }
 
 #[cfg(not(unix))]
@@ -908,7 +915,7 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn sticky_directory_replacement_requires_entry_or_directory_owner() {
-        let sticky_mode = libc::S_ISVTX as u32 | 0o777;
+        let sticky_mode = sticky_bit() | 0o777;
 
         assert!(!sticky_directory_allows_replacement(
             sticky_mode,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,19 @@ pub enum LinkPreviewState {
         /// A human-readable reason the link cannot be applied.
         reason: String,
     },
+    /// The link needs elevated privileges before it can be fully validated.
+    NeedsElevation {
+        /// A human-readable reason elevated validation is needed.
+        reason: String,
+    },
+}
+
+/// Options controlling how non-mutating previews inspect links.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct PreviewOptions {
+    /// Treat permission-denied system-link probes as needing elevated
+    /// validation instead of hard blockers.
+    pub system_links_may_use_elevation: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -152,16 +165,35 @@ impl DotConf {
 
     /// Inspect what applying the requested scope would do without changing files.
     pub fn preview(&self, scope: Scope) -> Result<Vec<LinkPreview>> {
+        self.preview_with_options(scope, PreviewOptions::default())
+    }
+
+    /// Inspect what applying the requested scope would do using preview options.
+    pub fn preview_with_options(
+        &self,
+        scope: Scope,
+        options: PreviewOptions,
+    ) -> Result<Vec<LinkPreview>> {
         let mut previews = Vec::new();
         match scope {
             Scope::All => {
-                self.preview_links(LinkScope::System, &self.sys_symlinks, &mut previews)?;
-                self.preview_links(LinkScope::User, &self.symlinks, &mut previews)?;
+                self.preview_links(
+                    LinkScope::System,
+                    &self.sys_symlinks,
+                    &mut previews,
+                    options,
+                )?;
+                self.preview_links(LinkScope::User, &self.symlinks, &mut previews, options)?;
             }
-            Scope::User => self.preview_links(LinkScope::User, &self.symlinks, &mut previews)?,
-            Scope::Sys => {
-                self.preview_links(LinkScope::System, &self.sys_symlinks, &mut previews)?
+            Scope::User => {
+                self.preview_links(LinkScope::User, &self.symlinks, &mut previews, options)?
             }
+            Scope::Sys => self.preview_links(
+                LinkScope::System,
+                &self.sys_symlinks,
+                &mut previews,
+                options,
+            )?,
         }
         Ok(previews)
     }
@@ -213,11 +245,28 @@ impl DotConf {
         scope: LinkScope,
         links: &BTreeMap<PathBuf, Vec<PathBuf>>,
         previews: &mut Vec<LinkPreview>,
+        options: PreviewOptions,
     ) -> Result<()> {
         for (source, destinations) in links {
             let source_exists = match fs::metadata(source) {
                 Ok(_) => true,
                 Err(err) if err.kind() == ErrorKind::NotFound => false,
+                Err(err) if should_defer_to_elevation(scope, options, err.kind()) => {
+                    for destination in destinations {
+                        previews.push(LinkPreview {
+                            scope,
+                            source: source.clone(),
+                            destination: destination.clone(),
+                            state: LinkPreviewState::NeedsElevation {
+                                reason: format!(
+                                    "failed inspecting source {} without elevated privileges: {err}",
+                                    source.display()
+                                ),
+                            },
+                        });
+                    }
+                    continue;
+                }
                 Err(err) => {
                     return Err(err)
                         .with_context(|| format!("failed inspecting {}", source.display()));
@@ -226,7 +275,7 @@ impl DotConf {
 
             for destination in destinations {
                 let state = if source_exists {
-                    preview_destination(&self.backup_directory, destination)?
+                    preview_destination(&self.backup_directory, destination, scope, options)?
                 } else {
                     LinkPreviewState::MissingSource
                 };
@@ -386,10 +435,36 @@ fn backup_and_remove_if_exists(backup_directory: &Path, destination: &Path) -> R
     )
 }
 
-fn preview_destination(backup_directory: &Path, destination: &Path) -> Result<LinkPreviewState> {
+fn preview_destination(
+    backup_directory: &Path,
+    destination: &Path,
+    scope: LinkScope,
+    options: PreviewOptions,
+) -> Result<LinkPreviewState> {
     let metadata = match fs::symlink_metadata(destination) {
         Ok(metadata) => metadata,
-        Err(err) if err.kind() == ErrorKind::NotFound => return Ok(LinkPreviewState::Create),
+        Err(err) if err.kind() == ErrorKind::NotFound => {
+            if let Some(problem) = validate_destination_parent(destination) {
+                return Ok(problem.into_preview_state(scope, options));
+            }
+            return Ok(LinkPreviewState::Create);
+        }
+        Err(err) if err.kind() == ErrorKind::NotADirectory => {
+            if let Some(problem) = validate_destination_parent(destination) {
+                return Ok(problem.into_preview_state(scope, options));
+            }
+            return Ok(LinkPreviewState::Blocked {
+                reason: format!("failed inspecting {}: {err}", destination.display()),
+            });
+        }
+        Err(err) if should_defer_to_elevation(scope, options, err.kind()) => {
+            return Ok(LinkPreviewState::NeedsElevation {
+                reason: format!(
+                    "failed inspecting destination {} without elevated privileges: {err}",
+                    destination.display()
+                ),
+            });
+        }
         Err(err) => {
             return Ok(LinkPreviewState::Blocked {
                 reason: format!("failed inspecting {}: {err}", destination.display()),
@@ -399,6 +474,9 @@ fn preview_destination(backup_directory: &Path, destination: &Path) -> Result<Li
 
     if metadata.file_type().is_symlink() {
         let target = symlink_backup_target(destination)?;
+        if let Some(problem) = validate_replacement_paths(backup_directory, destination) {
+            return Ok(problem.into_preview_state(scope, options));
+        }
         return Ok(LinkPreviewState::ReplaceSymlink {
             backup_directory: backup_directory.to_path_buf(),
             target,
@@ -406,6 +484,9 @@ fn preview_destination(backup_directory: &Path, destination: &Path) -> Result<Li
     }
 
     if metadata.is_file() {
+        if let Some(problem) = validate_replacement_paths(backup_directory, destination) {
+            return Ok(problem.into_preview_state(scope, options));
+        }
         return Ok(LinkPreviewState::ReplaceFile {
             backup_directory: backup_directory.to_path_buf(),
         });
@@ -414,6 +495,156 @@ fn preview_destination(backup_directory: &Path, destination: &Path) -> Result<Li
     Ok(LinkPreviewState::Blocked {
         reason: "destination exists and is not a file/symlink".to_string(),
     })
+}
+
+#[derive(Debug)]
+struct PreviewProblem {
+    reason: String,
+    elevation_may_fix: bool,
+}
+
+impl PreviewProblem {
+    fn blocked(reason: impl Into<String>) -> Self {
+        Self {
+            reason: reason.into(),
+            elevation_may_fix: false,
+        }
+    }
+
+    fn permission_denied(reason: impl Into<String>) -> Self {
+        Self {
+            reason: reason.into(),
+            elevation_may_fix: true,
+        }
+    }
+
+    fn into_preview_state(self, scope: LinkScope, options: PreviewOptions) -> LinkPreviewState {
+        if should_defer_problem_to_elevation(scope, options, self.elevation_may_fix) {
+            LinkPreviewState::NeedsElevation {
+                reason: self.reason,
+            }
+        } else {
+            LinkPreviewState::Blocked {
+                reason: self.reason,
+            }
+        }
+    }
+}
+
+fn validate_destination_parent(destination: &Path) -> Option<PreviewProblem> {
+    let parent = destination.parent().unwrap_or_else(|| Path::new("."));
+    validate_directory_creatable(parent).map(|problem| PreviewProblem {
+        reason: format!("destination parent: {}", problem.reason),
+        elevation_may_fix: problem.elevation_may_fix,
+    })
+}
+
+fn validate_replacement_paths(
+    backup_directory: &Path,
+    destination: &Path,
+) -> Option<PreviewProblem> {
+    if let Some(problem) = validate_directory_creatable(backup_directory) {
+        return Some(PreviewProblem {
+            reason: format!("backup directory: {}", problem.reason),
+            elevation_may_fix: problem.elevation_may_fix,
+        });
+    }
+    let parent = destination.parent().unwrap_or_else(|| Path::new("."));
+    validate_existing_directory_writable(parent).map(|problem| PreviewProblem {
+        reason: format!("destination parent: {}", problem.reason),
+        elevation_may_fix: problem.elevation_may_fix,
+    })
+}
+
+fn validate_directory_creatable(path: &Path) -> Option<PreviewProblem> {
+    let mut candidate = path;
+
+    loop {
+        match fs::symlink_metadata(candidate) {
+            Ok(metadata) => {
+                if !metadata.is_dir() {
+                    return Some(PreviewProblem::blocked(format!(
+                        "{} exists and is not a directory",
+                        candidate.display()
+                    )));
+                }
+                return validate_existing_directory_writable(candidate);
+            }
+            Err(err) if err.kind() == ErrorKind::NotFound => {
+                let Some(parent) = candidate.parent() else {
+                    return Some(PreviewProblem::blocked(format!(
+                        "failed finding existing parent for {}",
+                        path.display()
+                    )));
+                };
+                if parent == candidate {
+                    return Some(PreviewProblem::blocked(format!(
+                        "failed finding existing parent for {}",
+                        path.display()
+                    )));
+                }
+                candidate = parent;
+            }
+            Err(err) if err.kind() == ErrorKind::PermissionDenied => {
+                return Some(PreviewProblem::permission_denied(format!(
+                    "failed inspecting {}: {err}",
+                    candidate.display()
+                )));
+            }
+            Err(err) => {
+                return Some(PreviewProblem::blocked(format!(
+                    "failed inspecting {}: {err}",
+                    candidate.display()
+                )));
+            }
+        }
+    }
+}
+
+fn validate_existing_directory_writable(path: &Path) -> Option<PreviewProblem> {
+    if directory_is_writable(path) {
+        None
+    } else {
+        Some(PreviewProblem::permission_denied(format!(
+            "{} is not writable",
+            path.display()
+        )))
+    }
+}
+
+#[cfg(unix)]
+fn directory_is_writable(path: &Path) -> bool {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+
+    let Ok(path) = CString::new(path.as_os_str().as_bytes()) else {
+        return false;
+    };
+    unsafe { libc::access(path.as_ptr(), libc::W_OK) == 0 }
+}
+
+#[cfg(not(unix))]
+fn directory_is_writable(path: &Path) -> bool {
+    match fs::metadata(path) {
+        Ok(metadata) => !metadata.permissions().readonly(),
+        Err(_) => false,
+    }
+}
+
+fn should_defer_to_elevation(
+    scope: LinkScope,
+    options: PreviewOptions,
+    error_kind: ErrorKind,
+) -> bool {
+    should_defer_problem_to_elevation(scope, options, error_kind == ErrorKind::PermissionDenied)
+}
+
+fn should_defer_problem_to_elevation(
+    scope: LinkScope,
+    options: PreviewOptions,
+    elevation_may_fix: bool,
+) -> bool {
+    scope == LinkScope::System && options.system_links_may_use_elevation && elevation_may_fix
 }
 
 fn unique_backup_path(backup_directory: &Path, destination: &Path) -> Result<PathBuf> {
@@ -566,6 +797,18 @@ mod tests {
         let expanded = expand_tilde_with_home(&path, Some(Path::new("/tmp/home"))).unwrap();
 
         assert_eq!(expanded.as_os_str().as_bytes(), b"/tmp/home/foo\xffbar");
+    }
+
+    #[test]
+    fn elevated_system_preview_defers_permission_problem() {
+        let state = PreviewProblem::permission_denied("root-only").into_preview_state(
+            LinkScope::System,
+            PreviewOptions {
+                system_links_may_use_elevation: true,
+            },
+        );
+
+        assert!(matches!(state, LinkPreviewState::NeedsElevation { .. }));
     }
 
     #[cfg(windows)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -559,6 +559,13 @@ fn validate_replacement_paths(
             elevation_may_fix: problem.elevation_may_fix,
         });
     }
+    if let Some(problem) = validate_cross_device_file_backup_readable(
+        backup_directory,
+        destination,
+        destination_metadata,
+    ) {
+        return Some(problem);
+    }
     validate_sticky_directory_replacement(parent, destination, destination_metadata).map(
         |problem| PreviewProblem {
             reason: format!("destination parent: {}", problem.reason),
@@ -702,6 +709,124 @@ fn validate_sticky_directory_replacement(
     None
 }
 
+#[cfg(unix)]
+fn validate_cross_device_file_backup_readable(
+    backup_directory: &Path,
+    destination: &Path,
+    destination_metadata: &fs::Metadata,
+) -> Option<PreviewProblem> {
+    use std::os::unix::fs::MetadataExt;
+
+    if !destination_metadata.is_file() {
+        return None;
+    }
+
+    let destination_parent = destination.parent().unwrap_or_else(|| Path::new("."));
+    let destination_parent_metadata = match fs::metadata(destination_parent) {
+        Ok(metadata) => metadata,
+        Err(err) if err.kind() == ErrorKind::PermissionDenied => {
+            return Some(PreviewProblem::permission_denied(format!(
+                "destination parent: failed inspecting {}: {err}",
+                destination_parent.display()
+            )));
+        }
+        Err(err) => {
+            return Some(PreviewProblem::blocked(format!(
+                "destination parent: failed inspecting {}: {err}",
+                destination_parent.display()
+            )));
+        }
+    };
+    let backup_device = match creatable_directory_device(backup_directory) {
+        Ok(device) => device,
+        Err(problem) => {
+            return Some(PreviewProblem {
+                reason: format!("backup directory: {}", problem.reason),
+                elevation_may_fix: problem.elevation_may_fix,
+            });
+        }
+    };
+
+    if destination_parent_metadata.dev() != backup_device && !file_is_readable(destination) {
+        return Some(PreviewProblem::permission_denied(format!(
+            "{} is not readable; cross-device backups may need to copy it",
+            destination.display()
+        )));
+    }
+
+    None
+}
+
+#[cfg(not(unix))]
+fn validate_cross_device_file_backup_readable(
+    _backup_directory: &Path,
+    _destination: &Path,
+    _destination_metadata: &fs::Metadata,
+) -> Option<PreviewProblem> {
+    None
+}
+
+#[cfg(unix)]
+fn creatable_directory_device(path: &Path) -> std::result::Result<u64, PreviewProblem> {
+    use std::os::unix::fs::MetadataExt;
+
+    let mut candidate = path;
+
+    loop {
+        match fs::metadata(candidate) {
+            Ok(metadata) => return Ok(metadata.dev()),
+            Err(err) if err.kind() == ErrorKind::NotFound => {
+                match fs::symlink_metadata(candidate) {
+                    Ok(_) => {
+                        return Err(PreviewProblem::blocked(format!(
+                            "{} exists and is not a directory",
+                            candidate.display()
+                        )));
+                    }
+                    Err(err) if err.kind() == ErrorKind::NotFound => {}
+                    Err(err) if err.kind() == ErrorKind::PermissionDenied => {
+                        return Err(PreviewProblem::permission_denied(format!(
+                            "failed inspecting {}: {err}",
+                            candidate.display()
+                        )));
+                    }
+                    Err(err) => {
+                        return Err(PreviewProblem::blocked(format!(
+                            "failed inspecting {}: {err}",
+                            candidate.display()
+                        )));
+                    }
+                }
+                let Some(parent) = candidate.parent() else {
+                    return Err(PreviewProblem::blocked(format!(
+                        "failed finding existing parent for {}",
+                        path.display()
+                    )));
+                };
+                if parent == candidate {
+                    return Err(PreviewProblem::blocked(format!(
+                        "failed finding existing parent for {}",
+                        path.display()
+                    )));
+                }
+                candidate = parent;
+            }
+            Err(err) if err.kind() == ErrorKind::PermissionDenied => {
+                return Err(PreviewProblem::permission_denied(format!(
+                    "failed inspecting {}: {err}",
+                    candidate.display()
+                )));
+            }
+            Err(err) => {
+                return Err(PreviewProblem::blocked(format!(
+                    "failed inspecting {}: {err}",
+                    candidate.display()
+                )));
+            }
+        }
+    }
+}
+
 fn validate_existing_directory_writable(path: &Path) -> Option<PreviewProblem> {
     if directory_is_writable(path) {
         None
@@ -715,13 +840,23 @@ fn validate_existing_directory_writable(path: &Path) -> Option<PreviewProblem> {
 
 #[cfg(unix)]
 fn directory_is_writable(path: &Path) -> bool {
+    path_has_access(path, libc::W_OK | libc::X_OK)
+}
+
+#[cfg(unix)]
+fn file_is_readable(path: &Path) -> bool {
+    path_has_access(path, libc::R_OK)
+}
+
+#[cfg(unix)]
+fn path_has_access(path: &Path, mode: libc::c_int) -> bool {
     use std::ffi::CString;
     use std::os::unix::ffi::OsStrExt;
 
     let Ok(path) = CString::new(path.as_os_str().as_bytes()) else {
         return false;
     };
-    unsafe { libc::access(path.as_ptr(), libc::W_OK | libc::X_OK) == 0 }
+    unsafe { libc::access(path.as_ptr(), mode) == 0 }
 }
 
 #[cfg(not(unix))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,54 @@ pub enum Scope {
     Sys,
 }
 
+/// Which section a link came from.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum LinkScope {
+    /// A link from the `symlinks` section.
+    User,
+    /// A link from the `sys_symlinks` section.
+    System,
+}
+
+/// A non-mutating preview of a configured link.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct LinkPreview {
+    /// Whether the link came from `symlinks` or `sys_symlinks`.
+    pub scope: LinkScope,
+    /// The resolved source path.
+    pub source: PathBuf,
+    /// The resolved destination path.
+    pub destination: PathBuf,
+    /// What applying this link would do.
+    pub state: LinkPreviewState,
+}
+
+/// The result of inspecting one configured link without applying it.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum LinkPreviewState {
+    /// The source path is missing, so the link would be skipped.
+    MissingSource,
+    /// The destination is absent, so a new symlink would be created.
+    Create,
+    /// The destination is a file and would be backed up before replacement.
+    ReplaceFile {
+        /// The directory where the existing file would be backed up.
+        backup_directory: PathBuf,
+    },
+    /// The destination is a symlink and would be backed up before replacement.
+    ReplaceSymlink {
+        /// The directory where the existing symlink would be backed up.
+        backup_directory: PathBuf,
+        /// The resolved target of the existing symlink.
+        target: PathBuf,
+    },
+    /// The destination exists but cannot be replaced by this tool.
+    Blocked {
+        /// A human-readable reason the link cannot be applied.
+        reason: String,
+    },
+}
+
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct RawConfig {
@@ -102,6 +150,22 @@ impl DotConf {
         !self.sys_symlinks.is_empty()
     }
 
+    /// Inspect what applying the requested scope would do without changing files.
+    pub fn preview(&self, scope: Scope) -> Result<Vec<LinkPreview>> {
+        let mut previews = Vec::new();
+        match scope {
+            Scope::All => {
+                self.preview_links(LinkScope::System, &self.sys_symlinks, &mut previews)?;
+                self.preview_links(LinkScope::User, &self.symlinks, &mut previews)?;
+            }
+            Scope::User => self.preview_links(LinkScope::User, &self.symlinks, &mut previews)?,
+            Scope::Sys => {
+                self.preview_links(LinkScope::System, &self.sys_symlinks, &mut previews)?
+            }
+        }
+        Ok(previews)
+    }
+
     /// Apply configured symlinks for the requested scope.
     ///
     /// Existing file and symlink destinations are backed up before they are
@@ -139,6 +203,39 @@ impl DotConf {
                 }
                 backup_and_remove_if_exists(&self.backup_directory, destination)?;
                 create_symlink(source, destination)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn preview_links(
+        &self,
+        scope: LinkScope,
+        links: &BTreeMap<PathBuf, Vec<PathBuf>>,
+        previews: &mut Vec<LinkPreview>,
+    ) -> Result<()> {
+        for (source, destinations) in links {
+            let source_exists = match fs::metadata(source) {
+                Ok(_) => true,
+                Err(err) if err.kind() == ErrorKind::NotFound => false,
+                Err(err) => {
+                    return Err(err)
+                        .with_context(|| format!("failed inspecting {}", source.display()));
+                }
+            };
+
+            for destination in destinations {
+                let state = if source_exists {
+                    preview_destination(&self.backup_directory, destination)?
+                } else {
+                    LinkPreviewState::MissingSource
+                };
+                previews.push(LinkPreview {
+                    scope,
+                    source: source.clone(),
+                    destination: destination.clone(),
+                    state,
+                });
             }
         }
         Ok(())
@@ -287,6 +384,36 @@ fn backup_and_remove_if_exists(backup_directory: &Path, destination: &Path) -> R
         "destination {} exists and is not a file/symlink",
         destination.display()
     )
+}
+
+fn preview_destination(backup_directory: &Path, destination: &Path) -> Result<LinkPreviewState> {
+    let metadata = match fs::symlink_metadata(destination) {
+        Ok(metadata) => metadata,
+        Err(err) if err.kind() == ErrorKind::NotFound => return Ok(LinkPreviewState::Create),
+        Err(err) => {
+            return Ok(LinkPreviewState::Blocked {
+                reason: format!("failed inspecting {}: {err}", destination.display()),
+            });
+        }
+    };
+
+    if metadata.file_type().is_symlink() {
+        let target = symlink_backup_target(destination)?;
+        return Ok(LinkPreviewState::ReplaceSymlink {
+            backup_directory: backup_directory.to_path_buf(),
+            target,
+        });
+    }
+
+    if metadata.is_file() {
+        return Ok(LinkPreviewState::ReplaceFile {
+            backup_directory: backup_directory.to_path_buf(),
+        });
+    }
+
+    Ok(LinkPreviewState::Blocked {
+        reason: "destination exists and is not a file/symlink".to_string(),
+    })
 }
 
 fn unique_backup_path(backup_directory: &Path, destination: &Path) -> Result<PathBuf> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -474,7 +474,8 @@ fn preview_destination(
 
     if metadata.file_type().is_symlink() {
         let target = symlink_backup_target(destination)?;
-        if let Some(problem) = validate_replacement_paths(backup_directory, destination) {
+        if let Some(problem) = validate_replacement_paths(backup_directory, destination, &metadata)
+        {
             return Ok(problem.into_preview_state(scope, options));
         }
         return Ok(LinkPreviewState::ReplaceSymlink {
@@ -484,7 +485,8 @@ fn preview_destination(
     }
 
     if metadata.is_file() {
-        if let Some(problem) = validate_replacement_paths(backup_directory, destination) {
+        if let Some(problem) = validate_replacement_paths(backup_directory, destination, &metadata)
+        {
             return Ok(problem.into_preview_state(scope, options));
         }
         return Ok(LinkPreviewState::ReplaceFile {
@@ -542,6 +544,7 @@ fn validate_destination_parent(destination: &Path) -> Option<PreviewProblem> {
 fn validate_replacement_paths(
     backup_directory: &Path,
     destination: &Path,
+    destination_metadata: &fs::Metadata,
 ) -> Option<PreviewProblem> {
     if let Some(problem) = validate_directory_creatable(backup_directory) {
         return Some(PreviewProblem {
@@ -550,17 +553,25 @@ fn validate_replacement_paths(
         });
     }
     let parent = destination.parent().unwrap_or_else(|| Path::new("."));
-    validate_existing_directory_writable(parent).map(|problem| PreviewProblem {
-        reason: format!("destination parent: {}", problem.reason),
-        elevation_may_fix: problem.elevation_may_fix,
-    })
+    if let Some(problem) = validate_existing_directory_writable(parent) {
+        return Some(PreviewProblem {
+            reason: format!("destination parent: {}", problem.reason),
+            elevation_may_fix: problem.elevation_may_fix,
+        });
+    }
+    validate_sticky_directory_replacement(parent, destination, destination_metadata).map(
+        |problem| PreviewProblem {
+            reason: format!("destination parent: {}", problem.reason),
+            elevation_may_fix: problem.elevation_may_fix,
+        },
+    )
 }
 
 fn validate_directory_creatable(path: &Path) -> Option<PreviewProblem> {
     let mut candidate = path;
 
     loop {
-        match fs::symlink_metadata(candidate) {
+        match fs::metadata(candidate) {
             Ok(metadata) => {
                 if !metadata.is_dir() {
                     return Some(PreviewProblem::blocked(format!(
@@ -571,6 +582,27 @@ fn validate_directory_creatable(path: &Path) -> Option<PreviewProblem> {
                 return validate_existing_directory_writable(candidate);
             }
             Err(err) if err.kind() == ErrorKind::NotFound => {
+                match fs::symlink_metadata(candidate) {
+                    Ok(_) => {
+                        return Some(PreviewProblem::blocked(format!(
+                            "{} exists and is not a directory",
+                            candidate.display()
+                        )));
+                    }
+                    Err(err) if err.kind() == ErrorKind::NotFound => {}
+                    Err(err) if err.kind() == ErrorKind::PermissionDenied => {
+                        return Some(PreviewProblem::permission_denied(format!(
+                            "failed inspecting {}: {err}",
+                            candidate.display()
+                        )));
+                    }
+                    Err(err) => {
+                        return Some(PreviewProblem::blocked(format!(
+                            "failed inspecting {}: {err}",
+                            candidate.display()
+                        )));
+                    }
+                }
                 let Some(parent) = candidate.parent() else {
                     return Some(PreviewProblem::blocked(format!(
                         "failed finding existing parent for {}",
@@ -601,6 +633,68 @@ fn validate_directory_creatable(path: &Path) -> Option<PreviewProblem> {
     }
 }
 
+#[cfg(unix)]
+fn validate_sticky_directory_replacement(
+    parent: &Path,
+    destination: &Path,
+    destination_metadata: &fs::Metadata,
+) -> Option<PreviewProblem> {
+    use std::os::unix::fs::MetadataExt;
+
+    let parent_metadata = match fs::metadata(parent) {
+        Ok(metadata) => metadata,
+        Err(err) if err.kind() == ErrorKind::PermissionDenied => {
+            return Some(PreviewProblem::permission_denied(format!(
+                "failed inspecting {}: {err}",
+                parent.display()
+            )));
+        }
+        Err(err) => {
+            return Some(PreviewProblem::blocked(format!(
+                "failed inspecting {}: {err}",
+                parent.display()
+            )));
+        }
+    };
+    let euid = unsafe { libc::geteuid() };
+    if sticky_directory_allows_replacement(
+        parent_metadata.mode(),
+        parent_metadata.uid(),
+        destination_metadata.uid(),
+        euid,
+    ) {
+        return None;
+    }
+
+    Some(PreviewProblem::permission_denied(format!(
+        "{} is sticky and the current user does not own {}",
+        parent.display(),
+        destination.display()
+    )))
+}
+
+#[cfg(unix)]
+fn sticky_directory_allows_replacement(
+    parent_mode: u32,
+    parent_uid: u32,
+    destination_uid: u32,
+    euid: u32,
+) -> bool {
+    parent_mode & libc::S_ISVTX as u32 == 0
+        || euid == 0
+        || destination_uid == euid
+        || parent_uid == euid
+}
+
+#[cfg(not(unix))]
+fn validate_sticky_directory_replacement(
+    _parent: &Path,
+    _destination: &Path,
+    _destination_metadata: &fs::Metadata,
+) -> Option<PreviewProblem> {
+    None
+}
+
 fn validate_existing_directory_writable(path: &Path) -> Option<PreviewProblem> {
     if directory_is_writable(path) {
         None
@@ -620,7 +714,7 @@ fn directory_is_writable(path: &Path) -> bool {
     let Ok(path) = CString::new(path.as_os_str().as_bytes()) else {
         return false;
     };
-    unsafe { libc::access(path.as_ptr(), libc::W_OK) == 0 }
+    unsafe { libc::access(path.as_ptr(), libc::W_OK | libc::X_OK) == 0 }
 }
 
 #[cfg(not(unix))]
@@ -809,6 +903,38 @@ mod tests {
         );
 
         assert!(matches!(state, LinkPreviewState::NeedsElevation { .. }));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn sticky_directory_replacement_requires_entry_or_directory_owner() {
+        let sticky_mode = libc::S_ISVTX as u32 | 0o777;
+
+        assert!(!sticky_directory_allows_replacement(
+            sticky_mode,
+            1000,
+            1001,
+            1002
+        ));
+        assert!(sticky_directory_allows_replacement(
+            sticky_mode,
+            1000,
+            1001,
+            1001
+        ));
+        assert!(sticky_directory_allows_replacement(
+            sticky_mode,
+            1000,
+            1001,
+            1000
+        ));
+        assert!(sticky_directory_allows_replacement(
+            sticky_mode,
+            1000,
+            1001,
+            0
+        ));
+        assert!(sticky_directory_allows_replacement(0o777, 1000, 1001, 1002));
     }
 
     #[cfg(windows)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,7 @@
-use clap::Parser;
-use dot_conf::{DotConf, Scope};
+use anyhow::Context;
+use clap::{ArgAction, Parser, ValueEnum};
+use dot_conf::{DotConf, LinkPreview, LinkPreviewState, LinkScope, Scope};
+use log::LevelFilter;
 #[cfg(unix)]
 use std::env;
 use std::path::PathBuf;
@@ -7,40 +9,253 @@ use std::path::PathBuf;
 use std::process::Command;
 
 #[derive(Parser, Debug)]
-#[command(name = "dot-conf", about = "Apply dot-conf configuration files")]
+#[command(
+    name = "dot-conf",
+    version,
+    about = "Apply dot-conf configuration files",
+    long_about = "Apply dot-conf YAML configs by creating symlinks and backing up existing file or symlink destinations before replacement."
+)]
 struct Cli {
-    #[arg(required = true)]
+    #[arg(
+        value_name = "CONFIG",
+        required = true,
+        help = "YAML config file(s) to apply"
+    )]
     filenames: Vec<PathBuf>,
-    #[arg(long, conflicts_with = "user_only")]
+
+    #[arg(
+        long,
+        value_enum,
+        default_value = "all",
+        help = "Which config section(s) to apply"
+    )]
+    scope: CliScope,
+
+    #[arg(
+        long,
+        alias = "system-only",
+        conflicts_with_all = ["scope", "user_only"],
+        help = "Apply only sys_symlinks (alias for --scope system)"
+    )]
     sys_only: bool,
-    #[arg(long, conflicts_with = "sys_only")]
+
+    #[arg(
+        long,
+        conflicts_with_all = ["scope", "sys_only"],
+        help = "Apply only symlinks (alias for --scope user)"
+    )]
     user_only: bool,
+
+    #[arg(
+        long,
+        help = "Preview resolved changes without modifying files or invoking sudo"
+    )]
+    dry_run: bool,
+
+    #[arg(
+        short,
+        long,
+        action = ArgAction::Count,
+        conflicts_with = "quiet",
+        help = "Increase log verbosity (-v for info, -vv for debug)"
+    )]
+    verbose: u8,
+
+    #[arg(
+        short,
+        long,
+        action = ArgAction::Count,
+        conflicts_with = "verbose",
+        help = "Reduce log output (-q shows only errors, -qq disables logs)"
+    )]
+    quiet: u8,
 }
 
-fn main() -> anyhow::Result<()> {
-    env_logger::init();
-    let cli = Cli::parse();
-    let mut system_config_filenames = Vec::new();
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+enum CliScope {
+    All,
+    User,
+    System,
+}
 
-    for filename in &cli.filenames {
-        let config = DotConf::from_yaml_file(filename)?;
-        if cli.sys_only {
-            config.apply(Scope::Sys)?;
-        } else if cli.user_only {
-            config.apply(Scope::User)?;
-        } else if !config.requires_root() || is_elevated() {
-            config.apply(Scope::All)?;
+impl From<CliScope> for Scope {
+    fn from(scope: CliScope) -> Self {
+        match scope {
+            CliScope::All => Self::All,
+            CliScope::User => Self::User,
+            CliScope::System => Self::Sys,
+        }
+    }
+}
+
+impl Cli {
+    fn resolved_scope(&self) -> Scope {
+        if self.sys_only {
+            Scope::Sys
+        } else if self.user_only {
+            Scope::User
         } else {
-            config.apply(Scope::User)?;
-            system_config_filenames.push(filename);
+            self.scope.into()
         }
     }
 
-    if !system_config_filenames.is_empty() {
+    fn log_level_filter(&self) -> LevelFilter {
+        match self.quiet {
+            0 => match self.verbose {
+                0 => LevelFilter::Warn,
+                1 => LevelFilter::Info,
+                2 => LevelFilter::Debug,
+                _ => LevelFilter::Trace,
+            },
+            1 => LevelFilter::Error,
+            _ => LevelFilter::Off,
+        }
+    }
+}
+
+struct NamedConfig {
+    filename: PathBuf,
+    config: DotConf,
+}
+
+fn main() -> anyhow::Result<()> {
+    let cli = Cli::parse();
+    init_logger(&cli);
+
+    let configs = load_configs(&cli.filenames)?;
+    let scope = cli.resolved_scope();
+
+    if cli.dry_run {
+        return print_dry_run(&configs, scope);
+    }
+
+    apply_configs(&configs, scope)
+}
+
+fn init_logger(cli: &Cli) {
+    let mut builder =
+        env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("warn"));
+    if cli.verbose > 0 || cli.quiet > 0 {
+        builder.filter_level(cli.log_level_filter());
+    }
+    builder.format_timestamp(None).init();
+}
+
+fn load_configs(filenames: &[PathBuf]) -> anyhow::Result<Vec<NamedConfig>> {
+    filenames
+        .iter()
+        .map(|filename| {
+            Ok(NamedConfig {
+                filename: filename.clone(),
+                config: DotConf::from_yaml_file(filename)?,
+            })
+        })
+        .collect()
+}
+
+fn apply_configs(configs: &[NamedConfig], scope: Scope) -> anyhow::Result<()> {
+    if scope == Scope::All
+        && configs.iter().any(|config| config.config.requires_root())
+        && !is_elevated()
+    {
+        let system_config_filenames: Vec<_> = configs
+            .iter()
+            .filter(|config| config.config.requires_root())
+            .map(|config| config.filename.clone())
+            .collect();
         apply_system_config_with_elevation(&system_config_filenames)?;
+        return apply_scope(configs, Scope::User);
+    }
+
+    apply_scope(configs, scope)
+}
+
+fn apply_scope(configs: &[NamedConfig], scope: Scope) -> anyhow::Result<()> {
+    for named in configs {
+        named
+            .config
+            .apply(scope)
+            .with_context(|| format!("applying {}", named.filename.display()))?;
+    }
+    Ok(())
+}
+
+fn print_dry_run(configs: &[NamedConfig], scope: Scope) -> anyhow::Result<()> {
+    println!("Dry run: no files will be changed.");
+    if scope == Scope::All && configs.iter().any(|config| config.config.requires_root()) {
+        if is_elevated() {
+            println!("System links would be applied before user links.");
+        } else {
+            println!(
+                "System links would be applied first with sudo; user links would be applied only after that succeeds."
+            );
+        }
+    }
+
+    let mut blocked = false;
+    for named in configs {
+        let previews = named
+            .config
+            .preview(scope)
+            .with_context(|| format!("previewing {}", named.filename.display()))?;
+        println!();
+        println!("{}:", named.filename.display());
+        if previews.is_empty() {
+            println!("  no links for {}", scope_label(scope));
+            continue;
+        }
+        for preview in previews {
+            blocked |= matches!(&preview.state, LinkPreviewState::Blocked { .. });
+            print_preview(&preview);
+        }
+    }
+
+    if blocked {
+        anyhow::bail!("dry-run found destinations that cannot be replaced");
     }
 
     Ok(())
+}
+
+fn print_preview(preview: &LinkPreview) {
+    let scope = match preview.scope {
+        LinkScope::User => "user",
+        LinkScope::System => "system",
+    };
+    let source = preview.source.display();
+    let destination = preview.destination.display();
+
+    match &preview.state {
+        LinkPreviewState::MissingSource => {
+            println!("  [{scope}] skip {destination} -> {source} (source missing)");
+        }
+        LinkPreviewState::Create => {
+            println!("  [{scope}] create {destination} -> {source}");
+        }
+        LinkPreviewState::ReplaceFile { backup_directory } => {
+            println!("  [{scope}] replace file {destination} -> {source}");
+            println!("    backup directory: {}", backup_directory.display());
+        }
+        LinkPreviewState::ReplaceSymlink {
+            backup_directory,
+            target,
+        } => {
+            println!("  [{scope}] replace symlink {destination} -> {source}");
+            println!("    existing target: {}", target.display());
+            println!("    backup directory: {}", backup_directory.display());
+        }
+        LinkPreviewState::Blocked { reason } => {
+            println!("  [{scope}] blocked {destination} -> {source} ({reason})");
+        }
+    }
+}
+
+fn scope_label(scope: Scope) -> &'static str {
+    match scope {
+        Scope::All => "all scopes",
+        Scope::User => "user scope",
+        Scope::Sys => "system scope",
+    }
 }
 
 #[cfg(unix)]
@@ -54,13 +269,14 @@ fn is_elevated() -> bool {
 }
 
 #[cfg(unix)]
-fn apply_system_config_with_elevation(filenames: &[&PathBuf]) -> anyhow::Result<()> {
-    eprintln!("Enter password here to apply system config:");
+fn apply_system_config_with_elevation(filenames: &[PathBuf]) -> anyhow::Result<()> {
+    eprintln!("Applying system config with sudo:");
     let executable = env::current_exe()?;
     let status = Command::new("sudo")
         .arg("-E")
         .arg(executable)
-        .arg("--sys-only")
+        .arg("--scope")
+        .arg("system")
         .arg("--")
         .args(filenames.iter().map(|path| path.as_os_str()))
         .status()?;
@@ -75,19 +291,52 @@ fn apply_system_config_with_elevation(filenames: &[&PathBuf]) -> anyhow::Result<
 }
 
 #[cfg(not(unix))]
-fn apply_system_config_with_elevation(_filenames: &[&PathBuf]) -> anyhow::Result<()> {
+fn apply_system_config_with_elevation(_filenames: &[PathBuf]) -> anyhow::Result<()> {
     anyhow::bail!(
-        "system config requires elevated privileges; rerun with --sys-only from an elevated shell"
+        "system config requires elevated privileges; rerun with --scope system from an elevated shell"
     )
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use clap::CommandFactory;
 
     #[test]
     fn rejects_sys_only_with_user_only() {
         let result = Cli::try_parse_from(["dot-conf", "--sys-only", "--user-only", "config.yaml"]);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn resolves_scope_flag() {
+        let cli = Cli::try_parse_from(["dot-conf", "--scope", "system", "config.yaml"]).unwrap();
+        assert_eq!(cli.resolved_scope(), Scope::Sys);
+
+        let cli = Cli::try_parse_from(["dot-conf", "--scope", "user", "config.yaml"]).unwrap();
+        assert_eq!(cli.resolved_scope(), Scope::User);
+    }
+
+    #[test]
+    fn rejects_scope_with_legacy_scope_flag() {
+        let result = Cli::try_parse_from([
+            "dot-conf",
+            "--scope",
+            "system",
+            "--user-only",
+            "config.yaml",
+        ]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn help_includes_actionable_options() {
+        let mut command = Cli::command();
+        let help = command.render_long_help().to_string();
+
+        assert!(help.contains("--scope <SCOPE>"));
+        assert!(help.contains("--dry-run"));
+        assert!(help.contains("--version"));
+        assert!(help.contains("<CONFIG>..."));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use anyhow::Context;
 use clap::{ArgAction, Parser, ValueEnum};
-use dot_conf::{DotConf, LinkPreview, LinkPreviewState, LinkScope, Scope};
+use dot_conf::{DotConf, LinkPreview, LinkPreviewState, LinkScope, PreviewOptions, Scope};
 use log::LevelFilter;
 #[cfg(unix)]
 use std::env;
@@ -182,7 +182,8 @@ fn apply_scope(configs: &[NamedConfig], scope: Scope) -> anyhow::Result<()> {
 
 fn print_dry_run(configs: &[NamedConfig], scope: Scope) -> anyhow::Result<()> {
     println!("Dry run: no files will be changed.");
-    if scope == Scope::All && configs.iter().any(|config| config.config.requires_root()) {
+    let preview_options = preview_options(configs, scope);
+    if preview_options.system_links_may_use_elevation {
         if is_elevated() {
             println!("System links would be applied before user links.");
         } else {
@@ -196,7 +197,7 @@ fn print_dry_run(configs: &[NamedConfig], scope: Scope) -> anyhow::Result<()> {
     for named in configs {
         let previews = named
             .config
-            .preview(scope)
+            .preview_with_options(scope, preview_options)
             .with_context(|| format!("previewing {}", named.filename.display()))?;
         println!();
         println!("{}:", named.filename.display());
@@ -247,6 +248,17 @@ fn print_preview(preview: &LinkPreview) {
         LinkPreviewState::Blocked { reason } => {
             println!("  [{scope}] blocked {destination} -> {source} ({reason})");
         }
+        LinkPreviewState::NeedsElevation { reason } => {
+            println!("  [{scope}] needs elevated validation {destination} -> {source} ({reason})");
+        }
+    }
+}
+
+fn preview_options(configs: &[NamedConfig], scope: Scope) -> PreviewOptions {
+    PreviewOptions {
+        system_links_may_use_elevation: scope == Scope::All
+            && !is_elevated()
+            && configs.iter().any(|config| config.config.requires_root()),
     }
 }
 

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -144,3 +144,74 @@ backup_dir: ~/.config/misspelled
     assert!(stderr.contains("unknown field"));
     assert!(!home.join(".vimrc").exists());
 }
+
+#[test]
+#[serial]
+fn dry_run_fails_when_create_destination_parent_is_invalid() {
+    let tmp = tempdir().unwrap();
+    let root = tmp.path();
+    let home = root.join("home");
+    let cfg_dir = root.join("cfg");
+    fs::create_dir_all(&home).unwrap();
+    fs::create_dir_all(&cfg_dir).unwrap();
+
+    write_file(&cfg_dir.join(".vimrc"), "new");
+    write_file(&home.join("blocked"), "not a directory");
+    let yaml = cfg_dir.join("config.yaml");
+    fs::write(
+        &yaml,
+        format!(
+            "backup_directory: ~/.config/backup\nsymlinks:\n  .vimrc: {}\n",
+            home.join("blocked/.vimrc").display()
+        ),
+    )
+    .unwrap();
+
+    let output = dot_conf_with_home(&home)
+        .arg("--dry-run")
+        .arg(&yaml)
+        .output()
+        .unwrap();
+
+    assert_failure(&output);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("[user] blocked"));
+    assert!(stdout.contains("destination parent:"));
+    assert!(!home.join(".config/backup").exists());
+}
+
+#[test]
+#[serial]
+fn dry_run_fails_when_backup_directory_is_invalid() {
+    let tmp = tempdir().unwrap();
+    let root = tmp.path();
+    let home = root.join("home");
+    let cfg_dir = root.join("cfg");
+    fs::create_dir_all(&home).unwrap();
+    fs::create_dir_all(&cfg_dir).unwrap();
+
+    write_file(&cfg_dir.join(".vimrc"), "new");
+    write_file(&home.join(".vimrc"), "old");
+    write_file(&home.join("blocked"), "not a directory");
+    let yaml = cfg_dir.join("config.yaml");
+    fs::write(
+        &yaml,
+        format!(
+            "backup_directory: {}\nsymlinks:\n  .vimrc: ~/.vimrc\n",
+            home.join("blocked/backup").display()
+        ),
+    )
+    .unwrap();
+
+    let output = dot_conf_with_home(&home)
+        .arg("--dry-run")
+        .arg(&yaml)
+        .output()
+        .unwrap();
+
+    assert_failure(&output);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("[user] blocked"));
+    assert!(stdout.contains("backup directory:"));
+    assert_eq!(fs::read_to_string(home.join(".vimrc")).unwrap(), "old");
+}

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -215,3 +215,85 @@ fn dry_run_fails_when_backup_directory_is_invalid() {
     assert!(stdout.contains("backup directory:"));
     assert_eq!(fs::read_to_string(home.join(".vimrc")).unwrap(), "old");
 }
+
+#[cfg(unix)]
+#[test]
+#[serial]
+fn dry_run_accepts_symlinked_backup_directory() {
+    let tmp = tempdir().unwrap();
+    let root = tmp.path();
+    let home = root.join("home");
+    let cfg_dir = root.join("cfg");
+    let real_backup = home.join("real-backup");
+    let backup_link = home.join("backup-link");
+    fs::create_dir_all(&home).unwrap();
+    fs::create_dir_all(&cfg_dir).unwrap();
+    fs::create_dir_all(&real_backup).unwrap();
+    std::os::unix::fs::symlink(&real_backup, &backup_link).unwrap();
+
+    write_file(&cfg_dir.join(".vimrc"), "new");
+    write_file(&home.join(".vimrc"), "old");
+    let yaml = cfg_dir.join("config.yaml");
+    fs::write(
+        &yaml,
+        format!(
+            "backup_directory: {}\nsymlinks:\n  .vimrc: ~/.vimrc\n",
+            backup_link.display()
+        ),
+    )
+    .unwrap();
+
+    let output = dot_conf_with_home(&home)
+        .arg("--dry-run")
+        .arg(&yaml)
+        .output()
+        .unwrap();
+
+    assert_success(&output);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("[user] replace file"));
+    assert!(!stdout.contains("[user] blocked"));
+    assert_eq!(fs::read_to_string(home.join(".vimrc")).unwrap(), "old");
+}
+
+#[cfg(unix)]
+#[test]
+#[serial]
+fn dry_run_fails_when_backup_directory_lacks_search_permission() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let tmp = tempdir().unwrap();
+    let root = tmp.path();
+    let home = root.join("home");
+    let cfg_dir = root.join("cfg");
+    let backup_dir = home.join("backup");
+    fs::create_dir_all(&home).unwrap();
+    fs::create_dir_all(&cfg_dir).unwrap();
+    fs::create_dir_all(&backup_dir).unwrap();
+    fs::set_permissions(&backup_dir, fs::Permissions::from_mode(0o200)).unwrap();
+
+    write_file(&cfg_dir.join(".vimrc"), "new");
+    write_file(&home.join(".vimrc"), "old");
+    let yaml = cfg_dir.join("config.yaml");
+    fs::write(
+        &yaml,
+        format!(
+            "backup_directory: {}\nsymlinks:\n  .vimrc: ~/.vimrc\n",
+            backup_dir.display()
+        ),
+    )
+    .unwrap();
+
+    let output = dot_conf_with_home(&home)
+        .arg("--dry-run")
+        .arg(&yaml)
+        .output()
+        .unwrap();
+    fs::set_permissions(&backup_dir, fs::Permissions::from_mode(0o700)).unwrap();
+
+    assert_failure(&output);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("[user] blocked"));
+    assert!(stdout.contains("backup directory:"));
+    assert_eq!(fs::read_to_string(home.join(".vimrc")).unwrap(), "old");
+}

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -1,0 +1,146 @@
+use serial_test::serial;
+use std::fs;
+use std::path::Path;
+use std::process::{Command, Output};
+use tempfile::tempdir;
+
+fn write_file(path: &Path, contents: &str) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(path, contents).unwrap();
+}
+
+fn dot_conf_with_home(home: &Path) -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_dot-conf"));
+    command
+        .env("HOME", home)
+        .env("USERPROFILE", home)
+        .env_remove("HOMEDRIVE")
+        .env_remove("HOMEPATH")
+        .env_remove("RUST_LOG");
+    command
+}
+
+fn assert_success(output: &Output) {
+    assert!(
+        output.status.success(),
+        "expected success\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn assert_failure(output: &Output) {
+    assert!(
+        !output.status.success(),
+        "expected failure\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+#[serial]
+fn dry_run_reports_changes_without_mutating_files() {
+    let tmp = tempdir().unwrap();
+    let root = tmp.path();
+    let home = root.join("home");
+    let cfg_dir = root.join("cfg");
+    fs::create_dir_all(&home).unwrap();
+    fs::create_dir_all(&cfg_dir).unwrap();
+
+    write_file(&cfg_dir.join(".vimrc"), "new");
+    write_file(&home.join(".vimrc"), "old");
+    let yaml = cfg_dir.join("config.yaml");
+    fs::write(
+        &yaml,
+        r#"backup_directory: ~/.config/backup
+symlinks:
+  .vimrc: ~/.vimrc
+"#,
+    )
+    .unwrap();
+
+    let output = dot_conf_with_home(&home)
+        .arg("--dry-run")
+        .arg(&yaml)
+        .output()
+        .unwrap();
+
+    assert_success(&output);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Dry run: no files will be changed."));
+    assert!(stdout.contains("[user] replace file"));
+    assert!(stdout.contains("backup directory:"));
+    assert_eq!(fs::read_to_string(home.join(".vimrc")).unwrap(), "old");
+    assert!(!home.join(".config/backup").exists());
+}
+
+#[test]
+#[serial]
+fn missing_source_warning_is_visible_by_default() {
+    let tmp = tempdir().unwrap();
+    let root = tmp.path();
+    let home = root.join("home");
+    let cfg_dir = root.join("cfg");
+    fs::create_dir_all(&home).unwrap();
+    fs::create_dir_all(&cfg_dir).unwrap();
+
+    let yaml = cfg_dir.join("config.yaml");
+    fs::write(
+        &yaml,
+        r#"backup_directory: ~/.config/backup
+symlinks:
+  .missing: ~/.missing
+"#,
+    )
+    .unwrap();
+
+    let output = dot_conf_with_home(&home).arg(&yaml).output().unwrap();
+
+    assert_success(&output);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("skipping missing source"));
+}
+
+#[test]
+#[serial]
+fn invalid_later_config_does_not_apply_earlier_config() {
+    let tmp = tempdir().unwrap();
+    let root = tmp.path();
+    let home = root.join("home");
+    let cfg_dir = root.join("cfg");
+    fs::create_dir_all(&home).unwrap();
+    fs::create_dir_all(&cfg_dir).unwrap();
+
+    write_file(&cfg_dir.join(".vimrc"), "new");
+    let valid_yaml = cfg_dir.join("valid.yaml");
+    fs::write(
+        &valid_yaml,
+        r#"backup_directory: ~/.config/backup
+symlinks:
+  .vimrc: ~/.vimrc
+"#,
+    )
+    .unwrap();
+    let invalid_yaml = cfg_dir.join("invalid.yaml");
+    fs::write(
+        &invalid_yaml,
+        r#"backup_directory: ~/.config/backup
+backup_dir: ~/.config/misspelled
+"#,
+    )
+    .unwrap();
+
+    let output = dot_conf_with_home(&home)
+        .arg(&valid_yaml)
+        .arg(&invalid_yaml)
+        .output()
+        .unwrap();
+
+    assert_failure(&output);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("unknown field"));
+    assert!(!home.join(".vimrc").exists());
+}

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -262,6 +262,10 @@ fn dry_run_accepts_symlinked_backup_directory() {
 fn dry_run_fails_when_backup_directory_lacks_search_permission() {
     use std::os::unix::fs::PermissionsExt;
 
+    if unsafe { libc::geteuid() } == 0 {
+        return;
+    }
+
     let tmp = tempdir().unwrap();
     let root = tmp.path();
     let home = root.join("home");


### PR DESCRIPTION
## Summary

Adds user-facing CLI improvements for dot-conf:

- Add `--dry-run` preview output backed by a non-mutating `DotConf::preview` API.
- Add `--scope all|user|system`, `--version`, actionable help text, and `-v` / `-q` log controls while keeping `--user-only` and `--sys-only` compatibility.
- Parse all config files before applying changes and make mixed user/system applies run system links first, then user links only after sudo succeeds.
- Document the new CLI behavior and add CLI integration tests.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`