### PR TITLE
[codex] Reject self-mapping symlinks

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,6 +206,7 @@ impl DotConf {
                     fs::create_dir_all(parent)
                         .with_context(|| format!("failed creating {}", parent.display()))?;
                 }
+                ensure_source_and_destination_differ(source, destination)?;
                 backup_and_remove_if_exists(&self.backup_directory, destination)?;
                 create_symlink(source, destination)?;
             }
@@ -242,6 +243,44 @@ fn normalize_links(
         );
     }
     Ok(normalized)
+}
+
+fn ensure_source_and_destination_differ(source: &Path, destination: &Path) -> Result<()> {
+    if source == destination {
+        bail!(
+            "source and destination are the same path: {}",
+            source.display()
+        );
+    }
+
+    let destination_metadata = match fs::symlink_metadata(destination) {
+        Ok(metadata) => metadata,
+        Err(err) if err.kind() == ErrorKind::NotFound => return Ok(()),
+        Err(err) => {
+            return Err(err)
+                .with_context(|| format!("failed inspecting {}", destination.display()));
+        }
+    };
+
+    if destination_metadata.file_type().is_symlink() {
+        return Ok(());
+    }
+
+    let source = source
+        .canonicalize()
+        .with_context(|| format!("failed resolving {}", source.display()))?;
+    let destination = destination
+        .canonicalize()
+        .with_context(|| format!("failed resolving {}", destination.display()))?;
+
+    if source == destination {
+        bail!(
+            "source and destination resolve to the same path: {}",
+            source.display()
+        );
+    }
+
+    Ok(())
 }
 
 fn current_hostname() -> Result<String> {

--- a/tests/dot_conf_test.rs
+++ b/tests/dot_conf_test.rs
@@ -170,6 +170,42 @@ symlinks:
 
 #[test]
 #[serial]
+fn rejects_source_destination_self_mapping() {
+    let tmp = tempdir().unwrap();
+    let root = tmp.path();
+    let home = root.join("home");
+    let cfg_dir = root.join("cfg");
+    fs::create_dir_all(&home).unwrap();
+    fs::create_dir_all(&cfg_dir).unwrap();
+    with_home(&home, || {
+        let source = cfg_dir.join(".vimrc");
+        write_file(&source, "set nu");
+
+        let yaml = cfg_dir.join("config.yaml");
+        fs::write(
+            &yaml,
+            format!(
+                "backup_directory: ~/.config/backup\nsymlinks:\n  {}: {}\n",
+                source.display(),
+                source.display()
+            ),
+        )
+        .unwrap();
+
+        let err = DotConf::from_yaml_file(&yaml)
+            .unwrap()
+            .apply(Scope::User)
+            .unwrap_err();
+
+        assert!(format!("{err:#}").contains("source and destination are the same path"));
+        assert_eq!(fs::read_to_string(&source).unwrap(), "set nu");
+        assert!(!source.is_symlink());
+        assert!(!home.join(".config/backup").exists());
+    });
+}
+
+#[test]
+#[serial]
 fn applies_matching_host_links_only() {
     let tmp = tempdir().unwrap();
     let root = tmp.path();


### PR DESCRIPTION
## What changed

Reject configurations where a source and destination are the same path before backing up or replacing the destination.

## Why

A self-mapping like `file: file` could move the original file into backup storage and then create a self-referential symlink at the original path.

## Impact

Invalid self-mapping configs now fail early and leave the original file untouched.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- Manual self-map run preserves the source file and exits with an error.