### PR TITLE
[codex] Apply system config before user config

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,11 @@ use std::path::PathBuf;
 use std::process::Command;
 
 #[derive(Parser, Debug)]
-#[command(name = "dot-conf", about = "Apply dot-conf configuration files")]
+#[command(
+    name = "dot-conf",
+    version,
+    about = "Apply dot-conf configuration files"
+)]
 struct Cli {
     #[arg(required = true)]
     filenames: Vec<PathBuf>,
@@ -20,24 +24,43 @@ struct Cli {
 fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
     env_logger::init();
-    let mut system_config_filenames = Vec::new();
+    let configs = cli
+        .filenames
+        .iter()
+        .map(|filename| Ok((filename, DotConf::from_yaml_file(filename)?)))
+        .collect::<anyhow::Result<Vec<_>>>()?;
 
-    for filename in &cli.filenames {
-        let config = DotConf::from_yaml_file(filename)?;
-        if cli.sys_only {
+    if cli.sys_only {
+        for (_, config) in &configs {
             config.apply(Scope::Sys)?;
-        } else if cli.user_only {
-            config.apply(Scope::User)?;
-        } else if !config.requires_root() || is_elevated() {
-            config.apply(Scope::All)?;
-        } else {
-            config.apply(Scope::User)?;
-            system_config_filenames.push(filename);
         }
+        return Ok(());
     }
 
+    if cli.user_only {
+        for (_, config) in &configs {
+            config.apply(Scope::User)?;
+        }
+        return Ok(());
+    }
+
+    if is_elevated() {
+        for (_, config) in &configs {
+            config.apply(Scope::All)?;
+        }
+        return Ok(());
+    }
+
+    let system_config_filenames = configs
+        .iter()
+        .filter_map(|(filename, config)| config.requires_root().then_some(*filename))
+        .collect::<Vec<_>>();
     if !system_config_filenames.is_empty() {
         apply_system_config_with_elevation(&system_config_filenames)?;
+    }
+
+    for (_, config) in &configs {
+        config.apply(Scope::User)?;
     }
 
     Ok(())
@@ -89,5 +112,12 @@ mod tests {
     fn rejects_sys_only_with_user_only() {
         let result = Cli::try_parse_from(["dot-conf", "--sys-only", "--user-only", "config.yaml"]);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn supports_version_flag() {
+        let result = Cli::try_parse_from(["dot-conf", "--version"]);
+
+        assert!(result.is_err_and(|err| err.kind() == clap::error::ErrorKind::DisplayVersion));
     }
 }


### PR DESCRIPTION
## What changed

Load all requested configs first, apply elevated system config before user config when not already elevated, and add Clap version metadata so `dot-conf --version` works.

## Why

Previously the CLI applied user links before invoking sudo for system links. If the elevated system pass failed, user state had already changed. The package also had a version but no CLI version flag.

## Impact

Mixed user/system runs now avoid touching user files until the system pass succeeds. Users can also inspect the installed version with `--version`.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- Manual `cargo run --quiet -- --version` returned `dot-conf 0.1.0`.