### PR TITLE
[codex] Delay logger initialization until after CLI parse

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -18,8 +18,8 @@ struct Cli {
 }
 
 fn main() -> anyhow::Result<()> {
-    env_logger::init();
     let cli = Cli::parse();
+    env_logger::init();
     let mut system_config_filenames = Vec::new();
 
     for filename in &cli.filenames {


### PR DESCRIPTION
## Summary
- Move `env_logger::init()` until after `Cli::parse()` succeeds.
- Keeps logger initialization out of clap early-exit paths such as `--help` and argument validation errors.

## Benchmark notes
- Release startup is already around 2 ms on this machine.
- Direct old/new A/B showed this change is within benchmark noise, so this is a small cleanup rather than a material performance improvement.

## Validation
- `cargo test`