### PR TITLE
[codex] Add version output coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ dot-conf config.yaml
 
 Options:
 
+- `--version`, `-V` print the installed `dot-conf` version
 - `--dry-run` preview resolved changes and path blockers without modifying files or invoking `sudo`
 - `--scope all|user|system` choose which config section(s) to apply
 - `--user-only` only apply `symlinks` (alias for `--scope user`)

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -41,6 +41,36 @@ fn assert_failure(output: &Output) {
 }
 
 #[test]
+fn prints_version_with_long_flag() {
+    let output = Command::new(env!("CARGO_BIN_EXE_dot-conf"))
+        .arg("--version")
+        .output()
+        .unwrap();
+
+    assert_success(&output);
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        format!("dot-conf {}\n", env!("CARGO_PKG_VERSION"))
+    );
+    assert!(output.stderr.is_empty());
+}
+
+#[test]
+fn prints_version_with_short_flag() {
+    let output = Command::new(env!("CARGO_BIN_EXE_dot-conf"))
+        .arg("-V")
+        .output()
+        .unwrap();
+
+    assert_success(&output);
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        format!("dot-conf {}\n", env!("CARGO_PKG_VERSION"))
+    );
+    assert!(output.stderr.is_empty());
+}
+
+#[test]
 #[serial]
 fn dry_run_reports_changes_without_mutating_files() {
     let tmp = tempdir().unwrap();


### PR DESCRIPTION
## Summary

- Add CLI integration coverage for `dot-conf --version`.
- Add CLI integration coverage for `dot-conf -V`.
- Document the version flags in the README options list.

## Impact

Users can discover and rely on the installed version output. The behavior is backed by integration tests that assert exact stdout and no stderr.

## Validation

- `cargo fmt --check`
- `cargo test`