### PR TITLE
[codex] Harden dot-conf link handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## Why this version
 
 - **Simple mental model:** map `source -> destination` symlinks.
-- **Safe updates:** existing destination files are backed up before replacement.
+- **Safe updates:** existing destination files, directories, and symlinks are backed up before replacement.
 - **Flexible mapping:** one source can target many destinations.
 - **Intuitive tooling:** install from prebuilt binaries or `cargo`.
 
@@ -90,9 +90,11 @@ symlinks:
 - Destination and backup paths support `~` expansion for the current user's home directory.
 - A symlink entry can use `destinations` plus `host` or `hosts` to apply only on matching hostnames.
 - Missing source files are skipped with a warning.
+- Re-running an already-correct link leaves it in place without creating a backup.
 - Backup directories are created lazily only when an existing destination is backed up.
 - Backup filenames include the destination name, a readable UTC timestamp, and a destination hash.
 - Config files are all parsed before any changes are applied.
+- Duplicate source keys and duplicate destination mappings are rejected.
 - When applying both user and system links from a non-root shell, system links are applied with `sudo` first; user links are applied only after that succeeds.
 - Dry runs validate obvious destination and backup-directory blockers. System links that need `sudo` may be reported as needing elevated validation instead of hard-failing from a non-root preview.
 - Applying links is not transactional; if a later link in a scope fails, earlier links in that scope may already have been applied or backed up.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,9 +57,16 @@ pub enum LinkPreviewState {
     MissingSource,
     /// The destination is absent, so a new symlink would be created.
     Create,
+    /// The destination already links to the configured source.
+    Unchanged,
     /// The destination is a file and would be backed up before replacement.
     ReplaceFile {
         /// The directory where the existing file would be backed up.
+        backup_directory: PathBuf,
+    },
+    /// The destination is a directory and would be backed up before replacement.
+    ReplaceDirectory {
+        /// The directory where the existing directory would be backed up.
         backup_directory: PathBuf,
     },
     /// The destination is a symlink and would be backed up before replacement.
@@ -93,9 +100,9 @@ pub struct PreviewOptions {
 #[serde(deny_unknown_fields)]
 struct RawConfig {
     backup_directory: PathBuf,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_link_map")]
     symlinks: BTreeMap<PathBuf, RawLink>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_link_map")]
     sys_symlinks: BTreeMap<PathBuf, RawLink>,
 }
 
@@ -162,6 +169,41 @@ impl RawLink {
     }
 }
 
+fn deserialize_link_map<'de, D>(
+    deserializer: D,
+) -> std::result::Result<BTreeMap<PathBuf, RawLink>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    struct LinkMapVisitor;
+
+    impl<'de> serde::de::Visitor<'de> for LinkMapVisitor {
+        type Value = BTreeMap<PathBuf, RawLink>;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            formatter.write_str("a map from source paths to link definitions")
+        }
+
+        fn visit_map<M>(self, mut access: M) -> std::result::Result<Self::Value, M::Error>
+        where
+            M: serde::de::MapAccess<'de>,
+        {
+            let mut links = BTreeMap::new();
+            while let Some((source, link)) = access.next_entry::<PathBuf, RawLink>()? {
+                if links.insert(source.clone(), link).is_some() {
+                    return Err(serde::de::Error::custom(format!(
+                        "duplicate source path {}",
+                        source.display()
+                    )));
+                }
+            }
+            Ok(links)
+        }
+    }
+
+    deserializer.deserialize_map(LinkMapVisitor)
+}
+
 /// Parsed dot-conf configuration ready to apply.
 #[derive(Debug)]
 pub struct DotConf {
@@ -204,17 +246,47 @@ impl DotConf {
     /// current directory.
     pub fn from_yaml_str(yaml: &str, source_base: &Path, destination_base: &Path) -> Result<Self> {
         let raw: RawConfig = serde_yml::from_str(yaml).context("failed parsing YAML")?;
+        let backup_directory = resolve_against(source_base, &raw.backup_directory)
+            .with_context(|| format!("failed resolving {}", raw.backup_directory.display()))?;
+        let symlinks = normalize_links(source_base, destination_base, raw.symlinks)?;
+        let sys_symlinks = normalize_links(source_base, destination_base, raw.sys_symlinks)?;
+        validate_unique_destinations(&symlinks, &sys_symlinks)?;
+
         Ok(Self {
-            backup_directory: resolve_against(source_base, &raw.backup_directory)
-                .with_context(|| format!("failed resolving {}", raw.backup_directory.display()))?,
-            symlinks: normalize_links(source_base, destination_base, raw.symlinks)?,
-            sys_symlinks: normalize_links(source_base, destination_base, raw.sys_symlinks)?,
+            backup_directory,
+            symlinks,
+            sys_symlinks,
         })
     }
 
     /// Return whether this configuration includes system links.
     pub fn requires_root(&self) -> bool {
         !self.sys_symlinks.is_empty()
+    }
+
+    /// Return whether this configuration has system links for the current host.
+    pub fn requires_root_for_current_host(&self) -> Result<bool> {
+        let mut current_host = None;
+        for link in self.sys_symlinks.values() {
+            if link_applies_to_current_host(link, &mut current_host)? {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+
+    /// Return the resolved destination paths configured for the requested scope.
+    pub fn destinations(&self, scope: Scope) -> Vec<PathBuf> {
+        let mut destinations = Vec::new();
+        match scope {
+            Scope::All => {
+                collect_destinations(&self.sys_symlinks, &mut destinations);
+                collect_destinations(&self.symlinks, &mut destinations);
+            }
+            Scope::User => collect_destinations(&self.symlinks, &mut destinations),
+            Scope::Sys => collect_destinations(&self.sys_symlinks, &mut destinations),
+        }
+        destinations
     }
 
     /// Inspect what applying the requested scope would do without changing files.
@@ -267,8 +339,8 @@ impl DotConf {
 
     /// Apply configured symlinks for the requested scope.
     ///
-    /// Existing file and symlink destinations are backed up before they are
-    /// replaced. Missing source files are skipped with a warning.
+    /// Existing file, directory, and symlink destinations are backed up before
+    /// they are replaced. Missing source files are skipped with a warning.
     pub fn apply(&self, scope: Scope) -> Result<()> {
         let mut current_host = None;
         match scope {
@@ -288,14 +360,8 @@ impl DotConf {
         current_host: &mut Option<String>,
     ) -> Result<()> {
         for (source, link) in links {
-            if !link.hosts.is_empty() {
-                if current_host.is_none() {
-                    *current_host = Some(current_hostname()?);
-                }
-                let hostname = current_host.as_deref().expect("hostname was initialized");
-                if !host_matches(&link.hosts, hostname) {
-                    continue;
-                }
+            if !link_applies_to_current_host(link, current_host)? {
+                continue;
             }
 
             match fs::metadata(source) {
@@ -316,6 +382,9 @@ impl DotConf {
                         .with_context(|| format!("failed creating {}", parent.display()))?;
                 }
                 ensure_source_and_destination_differ(source, destination)?;
+                if destination_already_links_to_source(destination, source)? {
+                    continue;
+                }
                 backup_and_remove_if_exists(&self.backup_directory, destination)?;
                 create_symlink(source, destination)?;
             }
@@ -332,14 +401,8 @@ impl DotConf {
         current_host: &mut Option<String>,
     ) -> Result<()> {
         for (source, link) in links {
-            if !link.hosts.is_empty() {
-                if current_host.is_none() {
-                    *current_host = Some(current_hostname()?);
-                }
-                let hostname = current_host.as_deref().expect("hostname was initialized");
-                if !host_matches(&link.hosts, hostname) {
-                    continue;
-                }
+            if !link_applies_to_current_host(link, current_host)? {
+                continue;
             }
 
             let source_exists = match fs::metadata(source) {
@@ -369,7 +432,13 @@ impl DotConf {
 
             for destination in &link.destinations {
                 let state = if source_exists {
-                    preview_destination(&self.backup_directory, destination, scope, options)?
+                    preview_destination(
+                        &self.backup_directory,
+                        source,
+                        destination,
+                        scope,
+                        options,
+                    )?
                 } else {
                     LinkPreviewState::MissingSource
                 };
@@ -382,6 +451,12 @@ impl DotConf {
             }
         }
         Ok(())
+    }
+}
+
+fn collect_destinations(links: &BTreeMap<PathBuf, LinkConfig>, destinations: &mut Vec<PathBuf>) {
+    for link in links.values() {
+        destinations.extend(link.destinations.iter().cloned());
     }
 }
 
@@ -404,15 +479,59 @@ fn normalize_links(
                 })
             })
             .collect::<Result<Vec<_>>>()?;
-        normalized.insert(
-            resolved_source,
-            LinkConfig {
-                destinations: resolved_destinations,
-                hosts,
-            },
-        );
+        if normalized
+            .insert(
+                resolved_source.clone(),
+                LinkConfig {
+                    destinations: resolved_destinations,
+                    hosts,
+                },
+            )
+            .is_some()
+        {
+            bail!(
+                "source {} is configured more than once after path resolution",
+                resolved_source.display()
+            );
+        }
     }
     Ok(normalized)
+}
+
+fn validate_unique_destinations(
+    symlinks: &BTreeMap<PathBuf, LinkConfig>,
+    sys_symlinks: &BTreeMap<PathBuf, LinkConfig>,
+) -> Result<()> {
+    let mut seen = BTreeMap::new();
+    for (scope, links) in [
+        (LinkScope::User, symlinks),
+        (LinkScope::System, sys_symlinks),
+    ] {
+        for (source, link) in links {
+            for destination in &link.destinations {
+                if let Some((previous_scope, previous_source)) =
+                    seen.insert(destination.clone(), (scope, source.clone()))
+                {
+                    bail!(
+                        "destination {} is configured more than once ({} source {} and {} source {})",
+                        destination.display(),
+                        section_name(previous_scope),
+                        previous_source.display(),
+                        section_name(scope),
+                        source.display()
+                    );
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn section_name(scope: LinkScope) -> &'static str {
+    match scope {
+        LinkScope::User => "symlinks",
+        LinkScope::System => "sys_symlinks",
+    }
 }
 
 fn ensure_source_and_destination_differ(source: &Path, destination: &Path) -> Result<()> {
@@ -466,13 +585,15 @@ fn current_hostname() -> Result<String> {
 }
 
 fn host_matches(hosts: &[String], current_host: &str) -> bool {
-    let (current_short, current_is_fqdn) = hostname_parts(current_host);
+    let (current_short, _) = hostname_parts(current_host);
 
     hosts.iter().any(|host| {
-        let (host_short, host_is_fqdn) = hostname_parts(host);
-        host.eq_ignore_ascii_case(current_host)
-            || (!host_is_fqdn && host.eq_ignore_ascii_case(current_short))
-            || (!current_is_fqdn && host_short.eq_ignore_ascii_case(current_host))
+        let (_, host_is_fqdn) = hostname_parts(host);
+        if host_is_fqdn {
+            host.eq_ignore_ascii_case(current_host)
+        } else {
+            host.eq_ignore_ascii_case(current_short)
+        }
     })
 }
 
@@ -480,6 +601,20 @@ fn hostname_parts(hostname: &str) -> (&str, bool) {
     hostname
         .split_once('.')
         .map_or((hostname, false), |(short, _)| (short, true))
+}
+
+fn link_applies_to_current_host(
+    link: &LinkConfig,
+    current_host: &mut Option<String>,
+) -> Result<bool> {
+    if link.hosts.is_empty() {
+        return Ok(true);
+    }
+    if current_host.is_none() {
+        *current_host = Some(current_hostname()?);
+    }
+    let hostname = current_host.as_deref().expect("hostname was initialized");
+    Ok(host_matches(&link.hosts, hostname))
 }
 
 fn resolve_from_cwd(path: &Path) -> Result<PathBuf> {
@@ -597,14 +732,20 @@ fn backup_and_remove_if_exists(backup_directory: &Path, destination: &Path) -> R
         return Ok(());
     }
 
+    if metadata.is_dir() {
+        move_directory(destination, &backup)?;
+        return Ok(());
+    }
+
     bail!(
-        "destination {} exists and is not a file/symlink",
+        "destination {} exists and is not a file/directory/symlink",
         destination.display()
     )
 }
 
 fn preview_destination(
     backup_directory: &Path,
+    source: &Path,
     destination: &Path,
     scope: LinkScope,
     options: PreviewOptions,
@@ -642,6 +783,9 @@ fn preview_destination(
 
     if metadata.file_type().is_symlink() {
         let target = symlink_backup_target(destination)?;
+        if path_resolves_to_same_file(&target, source) {
+            return Ok(LinkPreviewState::Unchanged);
+        }
         if let Some(problem) = validate_replacement_paths(backup_directory, destination, &metadata)
         {
             return Ok(problem.into_preview_state(scope, options));
@@ -662,8 +806,18 @@ fn preview_destination(
         });
     }
 
+    if metadata.is_dir() {
+        if let Some(problem) = validate_replacement_paths(backup_directory, destination, &metadata)
+        {
+            return Ok(problem.into_preview_state(scope, options));
+        }
+        return Ok(LinkPreviewState::ReplaceDirectory {
+            backup_directory: backup_directory.to_path_buf(),
+        });
+    }
+
     Ok(LinkPreviewState::Blocked {
-        reason: "destination exists and is not a file/symlink".to_string(),
+        reason: "destination exists and is not a file/directory/symlink".to_string(),
     })
 }
 
@@ -1074,6 +1228,36 @@ fn backup_timestamp(now: SystemTime) -> Result<String> {
     Ok(timestamp.replace(':', "-"))
 }
 
+fn destination_already_links_to_source(destination: &Path, source: &Path) -> Result<bool> {
+    let metadata = match fs::symlink_metadata(destination) {
+        Ok(metadata) => metadata,
+        Err(err) if err.kind() == ErrorKind::NotFound => return Ok(false),
+        Err(err) => {
+            return Err(err)
+                .with_context(|| format!("failed inspecting {}", destination.display()));
+        }
+    };
+    if !metadata.file_type().is_symlink() {
+        return Ok(false);
+    }
+
+    let target = symlink_backup_target(destination)?;
+    Ok(path_resolves_to_same_file(&target, source))
+}
+
+fn path_resolves_to_same_file(left: &Path, right: &Path) -> bool {
+    if left == right {
+        return true;
+    }
+    let Ok(left) = left.canonicalize() else {
+        return false;
+    };
+    let Ok(right) = right.canonicalize() else {
+        return false;
+    };
+    left == right
+}
+
 fn symlink_backup_target(destination: &Path) -> Result<PathBuf> {
     let target = fs::read_link(destination)
         .with_context(|| format!("failed reading symlink {}", destination.display()))?;
@@ -1133,6 +1317,10 @@ fn move_or_copy_file(source: &Path, destination: &Path) -> Result<()> {
         }
         Err(err) => Err(err).with_context(|| format!("failed moving {}", source.display())),
     }
+}
+
+fn move_directory(source: &Path, destination: &Path) -> Result<()> {
+    fs::rename(source, destination).with_context(|| format!("failed moving {}", source.display()))
 }
 
 fn create_symlink(source: &Path, destination: &Path) -> Result<()> {
@@ -1268,7 +1456,7 @@ mod tests {
             &[String::from("WORKSTATION")],
             "workstation.example.test"
         ));
-        assert!(host_matches(
+        assert!(!host_matches(
             &[String::from("workstation.example.test")],
             "workstation"
         ));

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use anyhow::Context;
 use clap::{ArgAction, Parser, ValueEnum};
 use dot_conf::{DotConf, LinkPreview, LinkPreviewState, LinkScope, PreviewOptions, Scope};
 use log::LevelFilter;
+use std::collections::BTreeMap;
 #[cfg(unix)]
 use std::env;
 use std::path::PathBuf;
@@ -13,7 +14,7 @@ use std::process::Command;
     name = "dot-conf",
     version,
     about = "Apply dot-conf configuration files",
-    long_about = "Apply dot-conf YAML configs by creating symlinks and backing up existing file or symlink destinations before replacement."
+    long_about = "Apply dot-conf YAML configs by creating symlinks and backing up existing file, directory, or symlink destinations before replacement."
 )]
 struct Cli {
     #[arg(
@@ -122,8 +123,9 @@ fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
     init_logger(&cli);
 
-    let configs = load_configs(&cli.filenames)?;
     let scope = cli.resolved_scope();
+    let configs = load_configs(&cli.filenames)?;
+    validate_config_destinations(&configs, scope)?;
 
     if cli.dry_run {
         return print_dry_run(&configs, scope);
@@ -153,16 +155,26 @@ fn load_configs(filenames: &[PathBuf]) -> anyhow::Result<Vec<NamedConfig>> {
         .collect()
 }
 
+fn validate_config_destinations(configs: &[NamedConfig], scope: Scope) -> anyhow::Result<()> {
+    let mut seen = BTreeMap::new();
+    for named in configs {
+        for destination in named.config.destinations(scope) {
+            if let Some(previous) = seen.insert(destination.clone(), named.filename.clone()) {
+                anyhow::bail!(
+                    "destination {} is configured more than once ({} and {})",
+                    destination.display(),
+                    previous.display(),
+                    named.filename.display()
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
 fn apply_configs(configs: &[NamedConfig], scope: Scope) -> anyhow::Result<()> {
-    if scope == Scope::All
-        && configs.iter().any(|config| config.config.requires_root())
-        && !is_elevated()
-    {
-        let system_config_filenames: Vec<_> = configs
-            .iter()
-            .filter(|config| config.config.requires_root())
-            .map(|config| config.filename.clone())
-            .collect();
+    let system_config_filenames = system_config_filenames_requiring_elevation(configs, scope)?;
+    if !system_config_filenames.is_empty() && !is_elevated() {
         apply_system_config_with_elevation(&system_config_filenames)?;
         return apply_scope(configs, Scope::User);
     }
@@ -182,7 +194,7 @@ fn apply_scope(configs: &[NamedConfig], scope: Scope) -> anyhow::Result<()> {
 
 fn print_dry_run(configs: &[NamedConfig], scope: Scope) -> anyhow::Result<()> {
     println!("Dry run: no files will be changed.");
-    let preview_options = preview_options(configs, scope);
+    let preview_options = preview_options(configs, scope)?;
     if preview_options.system_links_may_use_elevation {
         if is_elevated() {
             println!("System links would be applied before user links.");
@@ -233,8 +245,15 @@ fn print_preview(preview: &LinkPreview) {
         LinkPreviewState::Create => {
             println!("  [{scope}] create {destination} -> {source}");
         }
+        LinkPreviewState::Unchanged => {
+            println!("  [{scope}] unchanged {destination} -> {source}");
+        }
         LinkPreviewState::ReplaceFile { backup_directory } => {
             println!("  [{scope}] replace file {destination} -> {source}");
+            println!("    backup directory: {}", backup_directory.display());
+        }
+        LinkPreviewState::ReplaceDirectory { backup_directory } => {
+            println!("  [{scope}] replace directory {destination} -> {source}");
             println!("    backup directory: {}", backup_directory.display());
         }
         LinkPreviewState::ReplaceSymlink {
@@ -254,12 +273,33 @@ fn print_preview(preview: &LinkPreview) {
     }
 }
 
-fn preview_options(configs: &[NamedConfig], scope: Scope) -> PreviewOptions {
-    PreviewOptions {
-        system_links_may_use_elevation: scope == Scope::All
-            && !is_elevated()
-            && configs.iter().any(|config| config.config.requires_root()),
+fn preview_options(configs: &[NamedConfig], scope: Scope) -> anyhow::Result<PreviewOptions> {
+    Ok(PreviewOptions {
+        system_links_may_use_elevation: !is_elevated()
+            && !system_config_filenames_requiring_elevation(configs, scope)?.is_empty(),
+    })
+}
+
+fn system_config_filenames_requiring_elevation(
+    configs: &[NamedConfig],
+    scope: Scope,
+) -> anyhow::Result<Vec<PathBuf>> {
+    if scope != Scope::All {
+        return Ok(Vec::new());
     }
+
+    configs
+        .iter()
+        .filter_map(
+            |config| match config.config.requires_root_for_current_host() {
+                Ok(true) => Some(Ok(config.filename.clone())),
+                Ok(false) => None,
+                Err(err) => Some(Err(err).with_context(|| {
+                    format!("checking system links for {}", config.filename.display())
+                })),
+            },
+        )
+        .collect()
 }
 
 fn scope_label(scope: Scope) -> &'static str {

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -22,6 +22,26 @@ fn dot_conf_with_home(home: &Path) -> Command {
     command
 }
 
+fn current_test_hostname() -> String {
+    hostname::get().unwrap().into_string().unwrap()
+}
+
+fn short_hostname(hostname: &str) -> &str {
+    hostname
+        .split_once('.')
+        .map_or(hostname, |(short, _)| short)
+}
+
+fn non_matching_hostname(hostname: &str) -> String {
+    let short = short_hostname(hostname);
+    let candidate = "dot-conf-unmatched-host";
+    if candidate.eq_ignore_ascii_case(hostname) || candidate.eq_ignore_ascii_case(short) {
+        "dot-conf-unmatched-host-2".to_string()
+    } else {
+        candidate.to_string()
+    }
+}
+
 fn assert_success(output: &Output) {
     assert!(
         output.status.success(),
@@ -105,6 +125,83 @@ symlinks:
     assert!(stdout.contains("backup directory:"));
     assert_eq!(fs::read_to_string(home.join(".vimrc")).unwrap(), "old");
     assert!(!home.join(".config/backup").exists());
+}
+
+#[test]
+#[serial]
+fn dry_run_does_not_report_sudo_for_host_skipped_system_links() {
+    let tmp = tempdir().unwrap();
+    let root = tmp.path();
+    let home = root.join("home");
+    let cfg_dir = root.join("cfg");
+    fs::create_dir_all(&home).unwrap();
+    fs::create_dir_all(&cfg_dir).unwrap();
+
+    let non_matching_host = non_matching_hostname(&current_test_hostname());
+    write_file(&cfg_dir.join(".vimrc"), "user");
+    write_file(&cfg_dir.join(".sysrc"), "sys");
+    let yaml = cfg_dir.join("config.yaml");
+    fs::write(
+        &yaml,
+        format!(
+            r#"backup_directory: ~/.config/backup
+symlinks:
+  .vimrc: ~/.vimrc
+sys_symlinks:
+  .sysrc:
+    destinations: /tmp/dot-conf-host-skipped-sysrc
+    host: {non_matching_host}
+"#
+        ),
+    )
+    .unwrap();
+
+    let output = dot_conf_with_home(&home)
+        .arg("--dry-run")
+        .arg(&yaml)
+        .output()
+        .unwrap();
+
+    assert_success(&output);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(!stdout.contains("sudo"));
+    assert!(stdout.contains("[user] create"));
+    assert!(!stdout.contains("[system]"));
+}
+
+#[test]
+#[serial]
+fn all_scope_applies_user_links_without_sudo_when_system_links_are_host_skipped() {
+    let tmp = tempdir().unwrap();
+    let root = tmp.path();
+    let home = root.join("home");
+    let cfg_dir = root.join("cfg");
+    fs::create_dir_all(&home).unwrap();
+    fs::create_dir_all(&cfg_dir).unwrap();
+
+    let non_matching_host = non_matching_hostname(&current_test_hostname());
+    write_file(&cfg_dir.join(".vimrc"), "user");
+    write_file(&cfg_dir.join(".sysrc"), "sys");
+    let yaml = cfg_dir.join("config.yaml");
+    fs::write(
+        &yaml,
+        format!(
+            r#"backup_directory: ~/.config/backup
+symlinks:
+  .vimrc: ~/.vimrc
+sys_symlinks:
+  .sysrc:
+    destinations: /tmp/dot-conf-host-skipped-sysrc
+    host: {non_matching_host}
+"#
+        ),
+    )
+    .unwrap();
+
+    let output = dot_conf_with_home(&home).arg(&yaml).output().unwrap();
+
+    assert_success(&output);
+    assert!(home.join(".vimrc").is_symlink());
 }
 
 #[test]

--- a/tests/dot_conf_test.rs
+++ b/tests/dot_conf_test.rs
@@ -3,7 +3,7 @@ use std::ffi::OsStr;
 use std::fs;
 use std::path::Path;
 
-use dot_conf::{DotConf, Scope};
+use dot_conf::{DotConf, LinkPreviewState, Scope};
 use tempfile::tempdir;
 
 fn write_file(path: &Path, contents: &str) {
@@ -165,6 +165,93 @@ symlinks:
         assert!(backup_name.contains('T'));
         assert!(backup_name.contains("Z."));
         assert!(!backup_name.contains(':'));
+    });
+}
+
+#[test]
+#[serial]
+fn reapplying_existing_link_is_noop() {
+    let tmp = tempdir().unwrap();
+    let root = tmp.path();
+    let home = root.join("home");
+    let cfg_dir = root.join("cfg");
+    fs::create_dir_all(&home).unwrap();
+    fs::create_dir_all(&cfg_dir).unwrap();
+    with_home(&home, || {
+        write_file(&cfg_dir.join(".vimrc"), "new");
+
+        let yaml = cfg_dir.join("config.yaml");
+        fs::write(
+            &yaml,
+            r#"backup_directory: ~/.config/backup
+symlinks:
+  .vimrc: ~/.vimrc
+"#,
+        )
+        .unwrap();
+
+        let conf = DotConf::from_yaml_file(&yaml).unwrap();
+        conf.apply(Scope::User).unwrap();
+
+        let previews = conf.preview(Scope::User).unwrap();
+        assert_eq!(previews.len(), 1);
+        assert!(matches!(previews[0].state, LinkPreviewState::Unchanged));
+
+        conf.apply(Scope::User).unwrap();
+
+        assert!(home.join(".vimrc").is_symlink());
+        assert_eq!(
+            home.join(".vimrc").canonicalize().unwrap(),
+            cfg_dir.join(".vimrc").canonicalize().unwrap()
+        );
+        assert!(!home.join(".config/backup").exists());
+    });
+}
+
+#[cfg(unix)]
+#[test]
+#[serial]
+fn creates_backup_for_existing_directories() {
+    let tmp = tempdir().unwrap();
+    let root = tmp.path();
+    let home = root.join("home");
+    let cfg_dir = root.join("cfg");
+    fs::create_dir_all(&home).unwrap();
+    fs::create_dir_all(&cfg_dir).unwrap();
+    with_home(&home, || {
+        write_file(&cfg_dir.join("nvim/init.lua"), "new");
+        write_file(&home.join(".config/nvim/init.lua"), "old");
+
+        let yaml = cfg_dir.join("config.yaml");
+        fs::write(
+            &yaml,
+            r#"backup_directory: ~/.config/backup
+symlinks:
+  nvim: ~/.config/nvim
+"#,
+        )
+        .unwrap();
+
+        DotConf::from_yaml_file(&yaml)
+            .unwrap()
+            .apply(Scope::User)
+            .unwrap();
+
+        let backups: Vec<_> = fs::read_dir(home.join(".config/backup"))
+            .unwrap()
+            .map(|entry| entry.unwrap().path())
+            .collect();
+        assert_eq!(backups.len(), 1);
+        assert!(backups[0].is_dir());
+        assert_eq!(
+            fs::read_to_string(backups[0].join("init.lua")).unwrap(),
+            "old"
+        );
+        assert!(home.join(".config/nvim").is_symlink());
+        assert_eq!(
+            home.join(".config/nvim").canonicalize().unwrap(),
+            cfg_dir.join("nvim").canonicalize().unwrap()
+        );
     });
 }
 
@@ -335,6 +422,34 @@ fn creates_distinct_backups_for_matching_destination_names() {
         backup_contents.sort();
         assert_eq!(backup_contents, vec!["old-a", "old-b"]);
     });
+}
+
+#[test]
+#[serial]
+fn rejects_duplicate_source_keys() {
+    let yaml = r#"backup_directory: ~/.config/backup
+symlinks:
+  .vimrc: ~/.vimrc
+  .vimrc: ~/.vimrc2
+"#;
+
+    let err = DotConf::from_yaml_str(yaml, Path::new("."), Path::new(".")).unwrap_err();
+
+    assert!(format!("{err:#}").contains("duplicate source path"));
+}
+
+#[test]
+#[serial]
+fn rejects_duplicate_destinations() {
+    let yaml = r#"backup_directory: ~/.config/backup
+symlinks:
+  vimrc: ~/.profile
+  profile: ~/.profile
+"#;
+
+    let err = DotConf::from_yaml_str(yaml, Path::new("."), Path::new(".")).unwrap_err();
+
+    assert!(format!("{err:#}").contains("configured more than once"));
 }
 
 #[test]

--- a/tests/real_use_test.rs
+++ b/tests/real_use_test.rs
@@ -1,0 +1,230 @@
+use serial_test::serial;
+use std::fs;
+use std::path::Path;
+#[cfg(unix)]
+use std::path::PathBuf;
+use std::process::{Command, Output};
+use tempfile::tempdir;
+
+fn write_file(path: &Path, contents: &str) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(path, contents).unwrap();
+}
+
+fn dot_conf_with_home(home: &Path) -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_dot-conf"));
+    command
+        .env("HOME", home)
+        .env("USERPROFILE", home)
+        .env_remove("HOMEDRIVE")
+        .env_remove("HOMEPATH")
+        .env_remove("RUST_LOG");
+    command
+}
+
+#[cfg(unix)]
+fn assert_success(output: &Output) {
+    assert!(
+        output.status.success(),
+        "expected success\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn assert_failure(output: &Output) {
+    assert!(
+        !output.status.success(),
+        "expected failure\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[cfg(unix)]
+fn backup_entries(home: &Path) -> Vec<PathBuf> {
+    let mut entries: Vec<_> = fs::read_dir(home.join(".config/backup"))
+        .unwrap()
+        .map(|entry| entry.unwrap().path())
+        .collect();
+    entries.sort();
+    entries
+}
+
+#[cfg(unix)]
+#[test]
+#[serial]
+fn workstation_bootstrap_is_previewable_repeatable_and_preserves_replaced_state() {
+    let tmp = tempdir().unwrap();
+    let root = tmp.path();
+    let home = root.join("home");
+    let dotfiles = root.join("dotfiles");
+    let system = root.join("system");
+    fs::create_dir_all(&home).unwrap();
+    fs::create_dir_all(&dotfiles).unwrap();
+    fs::create_dir_all(&system).unwrap();
+
+    write_file(&dotfiles.join(".vimrc"), "set number\n");
+    write_file(&dotfiles.join(".tmux.conf"), "set -g mouse on\n");
+    write_file(&dotfiles.join("nvim/init.lua"), "vim.o.number = true\n");
+    write_file(&dotfiles.join("sysctl.conf"), "kern.test=1\n");
+
+    write_file(&home.join(".vimrc"), "old vimrc\n");
+    write_file(&home.join(".config/nvim/init.lua"), "old nvim\n");
+    let old_tmux_target = home.join("old-tmux.conf");
+    write_file(&old_tmux_target, "old tmux\n");
+    std::os::unix::fs::symlink(&old_tmux_target, home.join(".tmux.conf")).unwrap();
+
+    let config = dotfiles.join("dot-conf.yaml");
+    fs::write(
+        &config,
+        format!(
+            r#"backup_directory: ~/.config/backup
+symlinks:
+  .vimrc: ~/.vimrc
+  .tmux.conf:
+    - ~/.tmux.conf
+    - ~/.config/tmux/tmux.conf
+  nvim: ~/.config/nvim
+sys_symlinks:
+  sysctl.conf: {}
+"#,
+            system.join("sysctl.conf").display()
+        ),
+    )
+    .unwrap();
+
+    let dry_run = dot_conf_with_home(&home)
+        .arg("--dry-run")
+        .arg(&config)
+        .output()
+        .unwrap();
+    assert_success(&dry_run);
+    let stdout = String::from_utf8_lossy(&dry_run.stdout);
+    assert!(stdout.contains("[user] replace file"));
+    assert!(stdout.contains("[user] replace symlink"));
+    assert!(stdout.contains("[user] replace directory"));
+    assert!(stdout.contains("[system] create"));
+    assert!(!home.join(".config/backup").exists());
+
+    let apply = dot_conf_with_home(&home)
+        .arg("--scope")
+        .arg("user")
+        .arg(&config)
+        .output()
+        .unwrap();
+    assert_success(&apply);
+
+    assert_eq!(
+        home.join(".vimrc").canonicalize().unwrap(),
+        dotfiles.join(".vimrc").canonicalize().unwrap()
+    );
+    assert_eq!(
+        home.join(".tmux.conf").canonicalize().unwrap(),
+        dotfiles.join(".tmux.conf").canonicalize().unwrap()
+    );
+    assert_eq!(
+        home.join(".config/tmux/tmux.conf").canonicalize().unwrap(),
+        dotfiles.join(".tmux.conf").canonicalize().unwrap()
+    );
+    assert_eq!(
+        home.join(".config/nvim").canonicalize().unwrap(),
+        dotfiles.join("nvim").canonicalize().unwrap()
+    );
+    assert!(!system.join("sysctl.conf").exists());
+
+    let backups = backup_entries(&home);
+    assert_eq!(backups.len(), 3);
+    assert!(backups.iter().any(|path| path
+        .file_name()
+        .unwrap()
+        .to_string_lossy()
+        .starts_with(".vimrc.")));
+    assert!(backups.iter().any(|path| path
+        .file_name()
+        .unwrap()
+        .to_string_lossy()
+        .starts_with(".tmux.conf.")));
+    assert!(backups.iter().any(|path| path
+        .file_name()
+        .unwrap()
+        .to_string_lossy()
+        .starts_with("nvim.")));
+    assert!(backups
+        .iter()
+        .any(|path| path.is_dir()
+            && fs::read_to_string(path.join("init.lua")).unwrap() == "old nvim\n"));
+    assert!(backups.iter().any(|path| path.is_symlink()
+        && path.canonicalize().unwrap() == old_tmux_target.canonicalize().unwrap()));
+    assert!(backups
+        .iter()
+        .any(|path| path.is_file() && fs::read_to_string(path).unwrap() == "old vimrc\n"));
+
+    let second_apply = dot_conf_with_home(&home)
+        .arg("--scope")
+        .arg("user")
+        .arg(&config)
+        .output()
+        .unwrap();
+    assert_success(&second_apply);
+    assert_eq!(backup_entries(&home).len(), 3);
+
+    let second_dry_run = dot_conf_with_home(&home)
+        .arg("--dry-run")
+        .arg("--scope")
+        .arg("user")
+        .arg(&config)
+        .output()
+        .unwrap();
+    assert_success(&second_dry_run);
+    let stdout = String::from_utf8_lossy(&second_dry_run.stdout);
+    assert_eq!(stdout.matches("[user] unchanged").count(), 4);
+    assert!(!stdout.contains("replace"));
+}
+
+#[test]
+#[serial]
+fn multiple_config_files_are_validated_before_any_link_is_applied() {
+    let tmp = tempdir().unwrap();
+    let root = tmp.path();
+    let home = root.join("home");
+    let dotfiles = root.join("dotfiles");
+    fs::create_dir_all(&home).unwrap();
+    fs::create_dir_all(&dotfiles).unwrap();
+
+    write_file(&dotfiles.join(".vimrc"), "set number\n");
+    write_file(&dotfiles.join(".gitconfig"), "[user]\n  name = Test\n");
+
+    let shell_config = dotfiles.join("shell.yaml");
+    fs::write(
+        &shell_config,
+        r#"backup_directory: ~/.config/backup
+symlinks:
+  .vimrc: ~/.vimrc
+"#,
+    )
+    .unwrap();
+
+    let git_config = dotfiles.join("git.yaml");
+    fs::write(
+        &git_config,
+        r#"backup_directory: ~/.config/backup
+symlinks:
+  .gitconfig: ~/.vimrc
+"#,
+    )
+    .unwrap();
+
+    let output = dot_conf_with_home(&home)
+        .arg(&shell_config)
+        .arg(&git_config)
+        .output()
+        .unwrap();
+
+    assert_failure(&output);
+    assert!(String::from_utf8_lossy(&output.stderr).contains("configured more than once"));
+    assert!(!home.join(".vimrc").exists());
+    assert!(!home.join(".config/backup").exists());
+}


### PR DESCRIPTION
## Summary

- Make reapplying existing correct symlinks a no-op and expose dry-run unchanged state
- Respect host filters before invoking sudo for system links
- Reject duplicate source and destination mappings before apply
- Back up existing directory destinations before replacing them

## Validation

- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test